### PR TITLE
Plan refactoring strategy and codify naming conventions (#34)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,7 @@ Full rules are in **`doc/CONVENTIONS.md`**. Key points:
 - **Functions**: action-first (`verb_object`), e.g. `handle_filters`, `generate_dot`.
 - **Classes**: PascalCase nouns, e.g. `Generator`, `FilterNeighbors`.
 - **Modules**: lowercase nouns (domain/role), e.g. `scanner`, `filters`.
-- **Packages**: generic → specific path order, e.g. `pipeline/scanner.py`.
+- **Packages**: generic → specific path order, e.g. `dsl/scanner.py`.
 - **Constants**: `UPPER_SNAKE_CASE` in their designated module.
 - Use official terminology from `doc/SYNTAX.md` in all identifiers.
 

--- a/devlog/034-plan-refactoring-strategy.md
+++ b/devlog/034-plan-refactoring-strategy.md
@@ -169,17 +169,17 @@ target layout defined in `doc/CONVENTIONS.md`, reducing `dfd.py` from
 
 **Actions anticipated:**
 
-- Create `pipeline/` sub-package:
-  - Move `scanner.py` → `pipeline/scanner.py`
-  - Move `parser.py` → `pipeline/parser.py`
+- Create `dsl/` sub-package:
+  - Move `scanner.py` → `dsl/scanner.py`
+  - Move `parser.py` → `dsl/parser.py`
   - Extract `handle_filters()` + `find_neighbors()` from `dfd.py` →
-    `pipeline/filters.py` (~260 lines, self-contained filter engine)
-  - Move `dependency_checker.py` → `pipeline/checker.py`
-- Create `codegen/` sub-package:
+    `dsl/filters.py` (~260 lines, self-contained filter engine)
+  - Move `dependency_checker.py` → `dsl/checker.py`
+- Create `rendering/` sub-package:
   - Extract `Generator` class + `generate_dot()` + `wrap()` from
-    `dfd.py` → `codegen/dot.py` (~300 lines, DOT generation)
-  - Move `dfd_dot_templates.py` → `codegen/templates.py`
-  - Move `dot.py` → `codegen/graphviz.py` (Graphviz binary
+    `dfd.py` → `rendering/dot.py` (~300 lines, DOT generation)
+  - Move `dfd_dot_templates.py` → `rendering/templates.py`
+  - Move `dot.py` → `rendering/graphviz.py` (Graphviz binary
     invocation)
 - Decide where `handle_options()` and `remove_unused_hidables()` fit:
   orchestrator (`dfd.py`) or one of the sub-packages.
@@ -237,9 +237,9 @@ coupling and making data flow explicit.
   Graphviz). Refactor so the core pipeline returns DOT text, and I/O
   is handled by the caller. This makes it possible to unit-test the
   full pipeline without touching the filesystem.
-- Ensure each extracted module (filters, codegen) exposes a pure
+- Ensure each extracted module (filters, rendering) exposes a pure
   function: statements in → statements out (filters), statements in →
-  DOT text out (codegen).
+  DOT text out (rendering).
 - Add unit tests that exercise each stage in isolation with
   programmatically constructed `model.Statements` (not just
   end-to-end `.dfd` → `.dot` comparisons).

--- a/doc/CONVENTIONS.md
+++ b/doc/CONVENTIONS.md
@@ -60,7 +60,7 @@ Rules:
 scanner.py          # what it is, not what it does
 parser.py
 filters.py
-codegen.py
+rendering.py
 templates.py
 ```
 
@@ -78,7 +78,7 @@ Rules:
 are ordered **generic to specific** (left to right):
 
 ```
-data_flow_diagram/pipeline/scanner.py
+data_flow_diagram/dsl/scanner.py
          ^            ^        ^
      package      domain    role
 ```
@@ -97,13 +97,13 @@ src/data_flow_diagram/
     model.py                # data types, exceptions, enums
     markdown.py             # markdown snippet extraction
     dfd.py                  # pipeline orchestrator (build)
-    pipeline/
+    dsl/
         __init__.py
         scanner.py          # preprocessing: includes, line continuations
         parser.py           # DSL parsing: keyword dispatch, syntactic sugar
         filters.py          # filter engine: only/without, neighbours
         checker.py          # cross-document dependency validation
-    codegen/
+    rendering/
         __init__.py
         dot.py              # DOT code generation (Generator class)
         templates.py        # DOT template strings and font constants
@@ -112,9 +112,9 @@ src/data_flow_diagram/
 
 Rationale:
 
-- **`pipeline/`** groups the DSL processing stages that transform
+- **`dsl/`** groups the DSL processing stages that transform
   source text into validated, filtered statements.
-- **`codegen/`** groups everything related to producing DOT output
+- **`rendering/`** groups everything related to producing DOT output
   and invoking Graphviz.
 - Top-level modules (`cli`, `config`, `console`, `model`, `markdown`,
   `dfd`) are either infrastructure shared across packages or entry
@@ -138,7 +138,7 @@ The package structure must work in all installation modes:
 - **Configuration values** (defaults, thresholds): define in
   `config.py` with `UPPER_SNAKE_CASE` names.
 - **Graphviz-specific constants** (templates, font specs, colours):
-  define in `codegen/templates.py`.
+  define in `rendering/templates.py`.
 - **DSL syntax literals** (sentinel values, directive keywords):
   define in `model.py` alongside the data types that use them.
 


### PR DESCRIPTION
## Summary

- **`doc/CONVENTIONS.md`**: authoritative developer reference for naming and structure conventions — action-first functions, PascalCase noun classes, noun-based modules, target package layout with `pipeline/` and `codegen/` sub-packages, constants placement rules
- **`devlog/034-plan-refactoring-strategy.md`**: sequenced refactoring plan with 8 tasks (A through J), dependency graph, and inter-aspect analysis
- **`CLAUDE.md`**: added summary section pointing to `doc/CONVENTIONS.md`

No production code changes. This is planning only.

## Refactoring sequence (summary)

| Order | Task | Description                                  |
| ----- | ---- | -------------------------------------------- |
| 1     | A    | Non-regression tests (anchor behaviour)      |
| 2     | B    | Consolidate scattered constants              |
| 3     | D    | Streamline error handling pattern             |
| 4     | C    | CLI entry point relocation                   |
| 5     | F    | Module boundaries + sub-packages             |
| 6     | H    | Break up large functions                     |
| 7     | I    | Improve testability (functional stages)      |
| 8     | J    | Align identifiers to glossary                |

## Test plan

- [x] Review `doc/CONVENTIONS.md` for completeness and accuracy
- [x] Review `devlog/034` task descriptions and dependency analysis
- [x] Verify target package layout is practical

🤖 Generated with [Claude Code](https://claude.com/claude-code)