### PR TITLE
Fix #65: crash on clean install (typing_extensions not found)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+## Version 1.16.8:
+
+- Fix #65: pip-installed package crashed on startup in a clean venv
+  (`ModuleNotFoundError: No module named 'typing_extensions'`). `Literal`
+  is now imported from stdlib `typing`; the `typing_extensions`
+  dependency is gone.
+
 ## Version 1.16.7.post2:
 
 - Bump to post2, to re-publish on PyPi.

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ require-system: ## install system packages (graphviz, python3-venv)
 
 require: ## install needed dev+install tools, in venv
 	. $(VENV)/bin/activate && \
-	pip install setuptools twine pytest typing_extensions mypy
+	pip install setuptools twine pytest mypy
 
 all: require-system venv require black lint test doc clean ## make all, except publish
 

--- a/TODO.md
+++ b/TODO.md
@@ -34,3 +34,13 @@ turned into a standard task (GH ticket, PR, devlog).
 
    Replaced relative image paths in README.md with absolute GitHub raw
    URLs so images render on both GitHub and PyPI.
+
+3. Include TestPyPI in a full testing cycle
+
+   Extend the release testing cycle to upload to TestPyPI
+   (`twine upload -r testpypi`) and install from there in a clean venv,
+   as an end-to-end test of the publishing pipeline before the real
+   PyPI upload. Context: #65 showed that install-time breakage (missing
+   dependency) is invisible to the dev-venv test suite; the clean-venv
+   wheel smoke test covers the artifact, TestPyPI would also cover the
+   transport/publishing path.

--- a/devlog/065-typing-extensions.md
+++ b/devlog/065-typing-extensions.md
@@ -2,7 +2,7 @@
 
 Date: 2026-08-05
 
-Status: ONGOING
+Status: DONE
 
 ## Requirement
 
@@ -48,3 +48,14 @@ Agreed implementation steps:
 
 No new NR fixtures: the change does not touch diagram-generation behavior;
 the clean-venv smoke test covers the actual failure mode.
+
+## Outcome
+
+- `console.py` now imports `Literal` from stdlib `typing`;
+  `typing_extensions` removed from `make require`.
+- `make black`, `make lint` (mypy strict), `make test` (60 pytest + 77 NR):
+  all pass.
+- Clean-venv smoke test: wheel installed into a fresh venv (only
+  `data-flow-diagram` present, no `typing_extensions`); `--help` and an NR
+  fixture render both succeed.
+- Version bumped to 1.16.8 in `CHANGES.md`.

--- a/devlog/065-typing-extensions.md
+++ b/devlog/065-typing-extensions.md
@@ -2,7 +2,7 @@
 
 Date: 2026-08-05
 
-Status: PENDING
+Status: ONGOING
 
 ## Requirement
 
@@ -36,4 +36,15 @@ This is a user-facing bug fix → PATCH version bump.
 
 ## Design
 
-(To be agreed before implementation.)
+Agreed implementation steps:
+
+1. Change `console.py` to `from typing import Literal`; remove
+   `typing_extensions` from the `make require` pip install list in the
+   Makefile.
+2. Run `make black`, `make lint`, `make test`.
+3. Clean-venv smoke test: build the package, `pip install` it into a fresh
+   venv, run `data-flow-diagram --help` and a small render.
+4. Bump version to 1.16.8, update `CHANGES.md`.
+
+No new NR fixtures: the change does not touch diagram-generation behavior;
+the clean-venv smoke test covers the actual failure mode.

--- a/devlog/065-typing-extensions.md
+++ b/devlog/065-typing-extensions.md
@@ -1,0 +1,39 @@
+# 065 — Crash on clean install: typing_extensions not found
+
+Date: 2026-08-05
+
+Status: PENDING
+
+## Requirement
+
+From issue [#65](https://github.com/pbauermeister/dfd/issues/65):
+
+When `data-flow-diagram` is installed in a clean venv
+(`pip install data_flow_diagram`), running it crashes at startup with
+`ModuleNotFoundError: No module named 'typing_extensions'`.
+
+- The only use is `from typing_extensions import Literal` in
+  `src/data_flow_diagram/console.py`.
+- `setup.py` declares `install_requires=[]`, so nothing pulls in
+  `typing_extensions`.
+- Dev environments mask the bug because `make require` installs
+  `typing_extensions` explicitly.
+
+### Mandated fix
+
+Do **not** add `typing_extensions` as a dependency. Instead, remove the need
+for it:
+
+1. In `console.py`, replace `from typing_extensions import Literal` with
+   `from typing import Literal` (stdlib since Python 3.8; the project requires
+   3.11+).
+2. Drop `typing_extensions` from the `make require` pip install list in the
+   Makefile.
+3. Verify with `make black`, `make lint`, `make test`, and a clean-venv smoke
+   test of the installed package.
+
+This is a user-facing bug fix → PATCH version bump.
+
+## Design
+
+(To be agreed before implementation.)

--- a/src/data_flow_diagram/console.py
+++ b/src/data_flow_diagram/console.py
@@ -1,5 +1,5 @@
 import sys
-from typing_extensions import Literal
+from typing import Literal
 
 
 def print_error(text: str) -> None:

--- a/tools/publish-to-github.py
+++ b/tools/publish-to-github.py
@@ -95,18 +95,21 @@ def create_release(version: str, changelog: str, dist_files: list[str]):
     print(f"\n--- Creating GitHub Release {tag} ---")
 
     # delete existing release if present
-    result = run(
-        ["gh", "release", "view", tag], check=False
-    )
+    result = run(["gh", "release", "view", tag], check=False)
     if result.returncode == 0:
         print(f"  Release {tag} exists, deleting...")
         run(["gh", "release", "delete", tag, "-y"])
 
     # create release with assets
     cmd = [
-        "gh", "release", "create", tag,
-        "--title", f"v{version}",
-        "--notes", changelog,
+        "gh",
+        "release",
+        "create",
+        tag,
+        "--title",
+        f"v{version}",
+        "--notes",
+        changelog,
     ] + dist_files
     run(cmd)
 


### PR DESCRIPTION
Fixes #65: pip-installed package crashed on startup in a clean venv because `console.py` imported `Literal` from `typing_extensions`, which was never declared as a dependency (`install_requires=[]`). Dev environments masked the bug because `make require` installed it explicitly.

Per the mandate, the dependency is removed rather than declared:

- [x] `console.py`: `from typing import Literal` (stdlib since 3.8; project requires 3.11+)
- [x] Makefile: drop `typing_extensions` from `make require`
- [x] `make black`, `make lint`, `make test` all pass
- [x] Clean-venv smoke test: wheel installed into a fresh venv, `--help` + NR-fixture render succeed with no `typing_extensions` present
- [x] Version bump to 1.16.8 in `CHANGES.md`

Devlog: [devlog/065-typing-extensions.md](https://github.com/pbauermeister/dfd/blob/fix/65-typing-extensions/devlog/065-typing-extensions.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)