### PR TITLE
Fix #67: escape labels in generated DOT output

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,12 @@
+## Version 1.16.9:
+
+- Fix #67: labels containing double quotes (or stray backslashes) produced
+  invalid DOT and crashed rendering. All values are now escaped for their
+  DOT emission context: quotes and stray backslashes in double-quoted
+  strings (item names and labels, connection labels, frame labels, graph
+  title); HTML entities in store/channel HTML-like labels. The documented
+  `\n` label escape (and `\l`/`\r`, reserved) still pass through.
+
 ## Version 1.16.8:
 
 - Fix #65: pip-installed package crashed on startup in a clean venv

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,11 +1,14 @@
 ## Version 1.16.9:
 
-- Fix #67: labels containing double quotes (or stray backslashes) produced
-  invalid DOT and crashed rendering. All values are now escaped for their
-  DOT emission context: quotes and stray backslashes in double-quoted
-  strings (item names and labels, connection labels, frame labels, graph
-  title); HTML entities in store/channel HTML-like labels. The documented
-  `\n` label escape (and `\l`/`\r`, reserved) still pass through.
+- Fix #67: labels containing double quotes produced invalid DOT and crashed
+  rendering. All values are now escaped for their DOT emission context:
+  quotes in double-quoted strings (item names and labels, connection labels,
+  frame labels, graph title); HTML entities in store/channel HTML-like
+  labels.
+- Labels form a small escape language: `\n` inserts a line break
+  (documented), `\\` a literal backslash; `\l`/`\r` are reserved (#59). Any
+  other backslash is now rejected with a clear error instead of producing
+  undefined DOT behavior.
 
 ## Version 1.16.8:
 

--- a/devlog/067-escape-dot-labels.md
+++ b/devlog/067-escape-dot-labels.md
@@ -2,7 +2,7 @@
 
 Date: 2026-08-05
 
-Status: PENDING
+Status: DONE
 
 ## Requirement
 
@@ -43,6 +43,59 @@ into (`\"` inside double-quoted attribute values; HTML entities inside
 HTML-like labels), so that any user-provided text renders instead of
 crashing.
 
+Additional finding during design: item *names* containing `"` also produce
+invalid DOT (names are emitted as `"{name}"` in node declarations, edge
+endpoints, and frame member lists). Same crash class; included in the fix
+with the same helper, applied consistently so declaration and references
+still match.
+
 ## Design
 
-(To be agreed before implementation.)
+Emission sites in `rendering/dot.py` / `rendering/templates.py`:
+
+| Context                    | Sites                                                | Escaping           |
+| -------------------------- | ---------------------------------------------------- | ------------------ |
+| Double-quoted DOT strings  | item labels (process, control, entity, none/star),   | `"` → `\"`,        |
+|                            | item names, edge endpoints + labels, frame labels +  | stray `\` → `\\`   |
+|                            | member refs, graph title                             |                    |
+| HTML-like labels           | store + channel `{text}` (and `{name}` is quoted)    | `html.escape`      |
+| DOT `/* */` comments       | `append()` source echo                               | break `*/`         |
+
+Backslash rule (refined on user request): a *stray* backslash — one not
+starting a recognized Graphviz label escape (`\n`, `\l`, `\r`, `\\`) — is
+escaped to `\\` so it renders literally and cannot eat the closing quote
+(e.g. a label ending in `\`). Recognized escapes are deliberately forwarded
+to Graphviz: `\n` is the DSL's documented line-break, `\l`/`\r` are reserved
+for TODO #59 alignment support.
+
+Implementation steps:
+
+1. Create NR fixture inputs: `072-label-quotes.dfd` (quotes in labels of all
+   plain-label item types, in an item name, in a connection label, in a frame
+   label) and `073-label-html.dfd` (store and channel labels containing `<`,
+   `>`, `&`).
+2. Implement escaping in `rendering/dot.py`: `escape_dot_string()` helper
+   applied at all double-quoted emission sites; `html.escape()` in
+   `_item_to_html_dict` (before the `\n` → `<br/>` substitution); sanitize
+   `*/` in `append()` comments. Graph title covered by the same helper, plus
+   a unit test (title with quote) since the title is not reachable from a
+   fixture file.
+3. `make nr-regenerate`, inspect SVGs, commit fixtures + goldens with the fix.
+4. `make black`, `make lint`, `make test`; mutation smoke-test: disable the
+   escaping, confirm 072/073 fail, revert.
+5. Bump to 1.16.9, update `CHANGES.md`; update PR body, mark ready.
+
+## Outcome
+
+- `_escape_dot_string()` in `rendering/dot.py` escapes `"` and stray `\` at
+  every double-quoted emission site (item names + labels, edge endpoints +
+  labels, frame labels + member refs, graph title); `html.escape()` covers
+  the store/channel HTML-like labels; `*/` is broken in source-echo comments.
+- New NR fixtures `072-label-quotes` (incl. quoted item name, backslash
+  cases, `\"` combination) and `073-label-html`; two new unit tests cover
+  the graph title and backslash rules. Existing 77 goldens byte-identical —
+  escaping is a no-op on all previous fixtures.
+- Mutation smoke-test: disabling `_escape_dot_string` fails 072 + 2 unit
+  tests; disabling `html.escape` fails 073. Both reverted.
+- Incidental discovery: a trailing `\` in a DSL line is consumed by the
+  scanner as line continuation, so it can never reach a rendered label.

--- a/devlog/067-escape-dot-labels.md
+++ b/devlog/067-escape-dot-labels.md
@@ -28,74 +28,76 @@ Confirmed scope:
 - **Node labels** — all item types that use plain `label="..."` attributes.
 - **Edge labels** — `P --> S data "x"` produces `[label="data "x""]`, same
   crash.
-
-Likely also affected (to verify during the task):
-
 - `DOT_GRAPH_TITLE` in `rendering/templates.py` interpolates `{title}` into
   `label="..."` unescaped.
 - Items rendered with HTML-like labels (`label=<...>`) have *different*
   escaping rules: `&`, `<`, `>` need HTML-entity escaping there.
 - Generated `/* N: source line */` comments would break if a source line
   contains `*/` (cosmetic/robustness, same family).
+- Item *names* containing `"` also produce invalid DOT (names are emitted
+  as `"{name}"` in node declarations, edge endpoints, and frame member
+  lists). Same crash class; fixed with the same helper, applied
+  consistently so declaration and references still match.
 
-Expected: label values must be escaped for the DOT context they are emitted
-into (`\"` inside double-quoted attribute values; HTML entities inside
-HTML-like labels), so that any user-provided text renders instead of
-crashing.
-
-Additional finding during design: item *names* containing `"` also produce
-invalid DOT (names are emitted as `"{name}"` in node declarations, edge
-endpoints, and frame member lists). Same crash class; included in the fix
-with the same helper, applied consistently so declaration and references
-still match.
+Decision on backslashes (agreed during specification): labels form a small
+escape language. Recognized escapes are `\n` (line break, documented),
+`\l` / `\r` (reserved for #59 alignment support), and `\\` (literal
+backslash). Any other backslash is **stray and rejected with an error** at
+check time — e.g. `C:\hello` fails, `C:\\hello` renders `C:\hello`. This
+keeps rendering predictable and lets future escapes be added without
+silently changing the meaning of existing diagrams.
 
 ## Design
 
-Emission sites in `rendering/dot.py` / `rendering/templates.py`:
-
-| Context                    | Sites                                                | Escaping           |
-| -------------------------- | ---------------------------------------------------- | ------------------ |
-| Double-quoted DOT strings  | item labels (process, control, entity, none/star),   | `"` → `\"`,        |
-|                            | item names, edge endpoints + labels, frame labels +  | stray `\` → `\\`   |
-|                            | member refs, graph title                             |                    |
-| HTML-like labels           | store + channel `{text}` (and `{name}` is quoted)    | `html.escape`      |
-| DOT `/* */` comments       | `append()` source echo                               | break `*/`         |
-
-Backslash rule (refined on user request): a *stray* backslash — one not
-starting a recognized Graphviz label escape (`\n`, `\l`, `\r`, `\\`) — is
-escaped to `\\` so it renders literally and cannot eat the closing quote
-(e.g. a label ending in `\`). Recognized escapes are deliberately forwarded
-to Graphviz: `\n` is the DSL's documented line-break, `\l`/`\r` are reserved
-for TODO #59 alignment support.
+| Context                    | Sites                                                | Handling             |
+| -------------------------- | ---------------------------------------------------- | -------------------- |
+| DSL labels and names       | item names + texts, connection texts, frame texts    | checker error on     |
+|                            |                                                      | stray `\`            |
+| Double-quoted DOT strings  | item labels (process, control, entity, none/star),   | `"` → `\"`; escapes  |
+|                            | item names, edge endpoints + labels, frame labels +  | (`\n` `\l` `\r` `\\`)|
+|                            | member refs, graph title                             | forwarded to dot     |
+| HTML-like labels           | store + channel `{text}` (and `{name}` is quoted)    | `html.escape`; then  |
+|                            |                                                      | `\\` → `\`,          |
+|                            |                                                      | `\n` → `<br/>`       |
+| DOT `/* */` comments       | `append()` source echo                               | break `*/`           |
 
 Implementation steps:
 
 1. Create NR fixture inputs: `072-label-quotes.dfd` (quotes in labels of all
    plain-label item types, in an item name, in a connection label, in a frame
-   label) and `073-label-html.dfd` (store and channel labels containing `<`,
-   `>`, `&`).
-2. Implement escaping in `rendering/dot.py`: `escape_dot_string()` helper
-   applied at all double-quoted emission sites; `html.escape()` in
-   `_item_to_html_dict` (before the `\n` → `<br/>` substitution); sanitize
-   `*/` in `append()` comments. Graph title covered by the same helper, plus
-   a unit test (title with quote) since the title is not reachable from a
-   fixture file.
-3. `make nr-regenerate`, inspect SVGs, commit fixtures + goldens with the fix.
-4. `make black`, `make lint`, `make test`; mutation smoke-test: disable the
-   escaping, confirm 072/073 fail, revert.
-5. Bump to 1.16.9, update `CHANGES.md`; update PR body, mark ready.
+   label; `\\` and `\n` cases), `073-label-html.dfd` (store and channel
+   labels containing `<`, `>`, `&`, `\\`), and `074-err-stray-backslash.dfd`
+   (error fixture).
+2. Implement: `_check_backslashes()` in `dsl/checker.py` (stray-backslash
+   error with source context); `escape` handling in `rendering/dot.py`
+   (`_escape_dot_string()` for quotes at all double-quoted emission sites,
+   escape translation in `_item_to_html_dict`, `*/` sanitization in
+   `append()`). Graph title covered by the same helper, plus unit tests
+   (title not reachable from a fixture file).
+3. `make nr-regenerate`, inspect outputs, commit fixtures + goldens with the
+   fix.
+4. `make black`, `make lint`, `make test`; mutation smoke-test each escaping
+   / validation path.
+5. Bump to 1.16.9, update `CHANGES.md` and `doc/README.md`; update PR body,
+   mark ready.
 
 ## Outcome
 
-- `_escape_dot_string()` in `rendering/dot.py` escapes `"` and stray `\` at
-  every double-quoted emission site (item names + labels, edge endpoints +
-  labels, frame labels + member refs, graph title); `html.escape()` covers
-  the store/channel HTML-like labels; `*/` is broken in source-echo comments.
-- New NR fixtures `072-label-quotes` (incl. quoted item name, backslash
-  cases, `\"` combination) and `073-label-html`; two new unit tests cover
-  the graph title and backslash rules. Existing 77 goldens byte-identical —
-  escaping is a no-op on all previous fixtures.
-- Mutation smoke-test: disabling `_escape_dot_string` fails 072 + 2 unit
-  tests; disabling `html.escape` fails 073. Both reverted.
+- Checker: stray backslashes in names/labels rejected with
+  `Stray backslash in "..."; use \\ for a literal backslash, \n for a line
+  break` (error-fixture `074-err-stray-backslash`).
+- Renderer: `"` → `\"` at every double-quoted emission site (item names +
+  labels, edge endpoints + labels, frame labels + member refs, graph
+  title); recognized escapes forwarded to Graphviz. HTML-like labels
+  (store/channel): HTML-entity escaping, then `\\` → `\` and
+  `\n` → `<br/>` translated left-to-right. `*/` broken in source-echo
+  comments.
+- `doc/README.md` documents the backslash rule next to the `\n` feature.
+- New NR fixtures 072/073/074 and 3 new unit tests (title quoting, escape
+  forwarding, stray-backslash error) + 1 checker robustness case. Existing
+  77 goldens byte-identical — the changes are a no-op on valid input.
+- Mutation smoke-tests: disabling quote escaping fails 072; disabling HTML
+  escaping fails 073; disabling the checker rule fails 074 + 2 unit tests.
+  All reverted.
 - Incidental discovery: a trailing `\` in a DSL line is consumed by the
   scanner as line continuation, so it can never reach a rendered label.

--- a/devlog/067-escape-dot-labels.md
+++ b/devlog/067-escape-dot-labels.md
@@ -1,0 +1,48 @@
+# 067 — Escape labels in generated DOT output
+
+Date: 2026-08-05
+
+Status: PENDING
+
+## Requirement
+
+From issue [#67](https://github.com/pbauermeister/dfd/issues/67):
+
+Any item or connection whose label contains a double quote produces invalid
+DOT and crashes rendering:
+
+```
+entity E name with "quotes"
+```
+
+generates
+
+```
+"E" [shape=rectangle label="name with "quotes"" ]
+```
+
+and `dot` fails with a syntax error.
+
+Confirmed scope:
+
+- **Node labels** — all item types that use plain `label="..."` attributes.
+- **Edge labels** — `P --> S data "x"` produces `[label="data "x""]`, same
+  crash.
+
+Likely also affected (to verify during the task):
+
+- `DOT_GRAPH_TITLE` in `rendering/templates.py` interpolates `{title}` into
+  `label="..."` unescaped.
+- Items rendered with HTML-like labels (`label=<...>`) have *different*
+  escaping rules: `&`, `<`, `>` need HTML-entity escaping there.
+- Generated `/* N: source line */` comments would break if a source line
+  contains `*/` (cosmetic/robustness, same family).
+
+Expected: label values must be escaped for the DOT context they are emitted
+into (`\"` inside double-quoted attribute values; HTML entities inside
+HTML-like labels), so that any user-provided text renders instead of
+crashing.
+
+## Design
+
+(To be agreed before implementation.)

--- a/doc/README.md
+++ b/doc/README.md
@@ -545,7 +545,9 @@ P1 -->  P3  [OK penwidth=2] all OK
 
 ### 3.7. Text wrapping and line breaks
 
-Newlines can be inserted in any label by means of `\n`.
+Newlines can be inserted in any label by means of `\n`. A literal
+backslash must be written `\\`; any other backslash sequence (except
+`\l` and `\r`, reserved for future alignment support) is an error.
 
 Lines are wrapped by default by:
 

--- a/src/data_flow_diagram/dsl/checker.py
+++ b/src/data_flow_diagram/dsl/checker.py
@@ -1,7 +1,12 @@
 """Validate parsed statements: items, connections, frames."""
 
+import re
+
 from .. import exception, model
 from ..model import Keyword
+
+# recognized label escapes: \n (line break), \l and \r (reserved), \\ (literal)
+RX_LABEL_ESCAPE = re.compile(r"\\[nlr\\]")
 
 
 def _check_items(statements: model.Statements) -> dict[str, model.Item]:
@@ -98,9 +103,32 @@ def _check_frames(
             framed_items.add(name)
 
 
+def _check_backslashes(statements: model.Statements) -> None:
+    """Reject stray backslashes in names and labels."""
+    for statement in statements:
+        match statement:
+            case model.Item() as item:
+                values = [item.name, item.text]
+            case model.Connection() as conn:
+                values = [conn.text or ""]
+            case model.Frame() as frame:
+                values = [frame.text]
+            case _:
+                continue
+        for value in values:
+            # a backslash surviving removal of recognized escapes is stray
+            if "\\" in RX_LABEL_ESCAPE.sub("", value):
+                raise exception.DfdException(
+                    f'Stray backslash in "{value}"; use \\\\ for a literal '
+                    "backslash, \\n for a line break",
+                    source=statement.source,
+                )
+
+
 def check(statements: model.Statements) -> dict[str, model.Item]:
     """Validate all statements: no duplicate items, valid connection endpoints, valid frames."""
     items_by_name = _check_items(statements)
     _check_connections(statements, items_by_name)
     _check_frames(statements, items_by_name)
+    _check_backslashes(statements)
     return items_by_name

--- a/src/data_flow_diagram/rendering/dot.py
+++ b/src/data_flow_diagram/rendering/dot.py
@@ -1,5 +1,6 @@
 """DOT code generation: Generator class and statement-to-DOT dispatch."""
 
+import html
 import pprint
 import re
 import textwrap
@@ -7,6 +8,19 @@ from typing import Any
 
 from .. import exception, model
 from . import templates as TMPL
+
+# backslash not starting a recognized Graphviz label escape (\n \l \r \\)
+RX_STRAY_BACKSLASH = re.compile(r'\\(?![nlr\\])')
+
+
+def _escape_dot_string(s: str) -> str:
+    """Escape a value for embedding in a double-quoted DOT string.
+
+    Escapes double quotes and stray backslashes; recognized label escapes
+    (\\n, \\l, \\r, \\\\) are deliberately forwarded to Graphviz.
+    """
+    s = RX_STRAY_BACKSLASH.sub(r'\\\\', s)
+    return s.replace('"', '\\"')
 
 
 def _strip_quotes(s: str) -> str:
@@ -56,7 +70,8 @@ class Generator:
 
     def append(self, line: str, statement: model.Statement) -> None:
         self.lines.append("")
-        text = model.pack(statement.source.text)
+        # break any */ in the source echo so the DOT comment stays valid
+        text = model.pack(statement.source.text).replace("*/", "* /")
         self.lines.append(f"/* {statement.source.line_nr}: {text} */")
         self.lines.append(line)
 
@@ -73,6 +88,10 @@ class Generator:
         attrs = copy.attrs or ""
         attrs = self._expand_attribs(attrs)
 
+        # escape for the double-quoted emission sites below
+        name = _escape_dot_string(copy.name)
+        text = _escape_dot_string(copy.text)
+
         # emit shape-specific DOT declaration
         match copy.type:
             case model.Keyword.PROCESS:
@@ -83,24 +102,26 @@ class Generator:
                     shape = TMPL.SHAPE_PROCESS
                     fc = TMPL.FILL_PROCESS
                 line = (
-                    f'"{copy.name}" [shape={shape} label="{copy.text}" '
+                    f'"{name}" [shape={shape} label="{text}" '
                     f"fillcolor={fc} style={TMPL.STYLE_PROCESS} {attrs}]"
                 )
             case model.Keyword.CONTROL:
                 line = (
-                    f'"{copy.name}" [shape={TMPL.SHAPE_PROCESS} label="{copy.text}" '
+                    f'"{name}" [shape={TMPL.SHAPE_PROCESS} label="{text}" '
                     f'fillcolor={TMPL.FILL_PROCESS} style={TMPL.STYLE_CONTROL} {attrs}]'
                 )
             case model.Keyword.ENTITY:
                 line = (
-                    f'"{copy.name}" [shape={TMPL.SHAPE_ENTITY} label="{copy.text}" '
+                    f'"{name}" [shape={TMPL.SHAPE_ENTITY} label="{text}" '
                     f"{attrs}]"
                 )
             case model.Keyword.STORE:
                 d = self._attrib_to_dict(copy, attrs)
                 line = TMPL.STORE.format(**d)
             case model.Keyword.NONE | model.Keyword.STAR:
-                line = f'"{copy.name}" [shape={TMPL.SHAPE_NONE} label="{copy.text}" {attrs}]'
+                line = (
+                    f'"{name}" [shape={TMPL.SHAPE_NONE} label="{text}" {attrs}]'
+                )
             case model.Keyword.CHANNEL:
                 d = self._attrib_to_dict(copy, attrs)
                 if self.graph_options.is_vertical:
@@ -127,7 +148,9 @@ class Generator:
 
     def _item_to_html_dict(self, item: model.Item) -> dict[str, Any]:
         d = item.__dict__
-        d["text"] = d["text"].replace("\\n", "<br/>")
+        # HTML-like label context: entity-escape, then turn \n into <br/>
+        d["text"] = html.escape(d["text"]).replace("\\n", "<br/>")
+        d["name"] = _escape_dot_string(d["name"])
         return d
 
     def _compile_attribs_names(
@@ -158,7 +181,7 @@ class Generator:
 
     def _build_connection_attrs(self, conn: model.Connection, text: str) -> str:
         """Build the DOT attribute string for a connection edge."""
-        attrs = f'label="{text}"'
+        attrs = f'label="{_escape_dot_string(text)}"'
 
         # constraints are invisible layout-only edges
         match conn.type:
@@ -221,7 +244,9 @@ class Generator:
         )
 
         attrs = self._build_connection_attrs(conn, text)
-        line = f'"{src_item.name}"{src_port} -> "{dst_item.name}"{dst_port} [{attrs}]'
+        src_name = _escape_dot_string(src_item.name)
+        dst_name = _escape_dot_string(dst_item.name)
+        line = f'"{src_name}"{src_port} -> "{dst_name}"{dst_port} [{attrs}]'
         self.append(line, conn)
 
     def generate_style(self, style: model.Style) -> None:
@@ -231,13 +256,13 @@ class Generator:
         self.append(f"subgraph cluster_{self.frame_nr} {{", frame)
         self.frame_nr += 1
 
-        self.lines.append(f'  label="{frame.text}"')
+        self.lines.append(f'  label="{_escape_dot_string(frame.text)}"')
         if frame.attrs:
             attrs = self._expand_attribs(frame.attrs)
             self.lines.append(f"  {attrs}")
 
         for item in frame.items:
-            self.lines.append(f'  "{item}"')
+            self.lines.append(f'  "{_escape_dot_string(item)}"')
         self.lines.append("}")
 
     def generate_dot_text(self, title: str, bg_color: str | None) -> str:
@@ -250,7 +275,10 @@ class Generator:
             graph_params.append(TMPL.GRAPH_PARAMS_CONTEXT_DIAGRAM)
 
         if title:
-            graph_params.append(TMPL.DOT_GRAPH_TITLE.format(title=title))
+            escaped_title = _escape_dot_string(title)
+            graph_params.append(
+                TMPL.DOT_GRAPH_TITLE.format(title=escaped_title)
+            )
         else:
             graph_params.append(TMPL.DOT_GRAPH_NOTITLE)
 

--- a/src/data_flow_diagram/rendering/dot.py
+++ b/src/data_flow_diagram/rendering/dot.py
@@ -9,17 +9,17 @@ from typing import Any
 from .. import exception, model
 from . import templates as TMPL
 
-# backslash not starting a recognized Graphviz label escape (\n \l \r \\)
-RX_STRAY_BACKSLASH = re.compile(r'\\(?![nlr\\])')
+# label escapes needing translation in HTML-like label context
+RX_HTML_LABEL_ESCAPE = re.compile(r"\\(\\|n)")
 
 
 def _escape_dot_string(s: str) -> str:
     """Escape a value for embedding in a double-quoted DOT string.
 
-    Escapes double quotes and stray backslashes; recognized label escapes
-    (\\n, \\l, \\r, \\\\) are deliberately forwarded to Graphviz.
+    Only double quotes need escaping: the checker rejects stray
+    backslashes, and recognized label escapes (\\n, \\l, \\r, \\\\) are
+    deliberately forwarded to Graphviz.
     """
-    s = RX_STRAY_BACKSLASH.sub(r'\\\\', s)
     return s.replace('"', '\\"')
 
 
@@ -148,8 +148,12 @@ class Generator:
 
     def _item_to_html_dict(self, item: model.Item) -> dict[str, Any]:
         d = item.__dict__
-        # HTML-like label context: entity-escape, then turn \n into <br/>
-        d["text"] = html.escape(d["text"]).replace("\\n", "<br/>")
+        # HTML-like label context: entity-escape, then translate label
+        # escapes left-to-right (\\ -> literal backslash, \n -> <br/>)
+        d["text"] = RX_HTML_LABEL_ESCAPE.sub(
+            lambda m: "<br/>" if m[1] == "n" else "\\",
+            html.escape(d["text"]),
+        )
         d["name"] = _escape_dot_string(d["name"])
         return d
 

--- a/tests/non-regression/072-label-quotes.dfd
+++ b/tests/non-regression/072-label-quotes.dfd
@@ -7,11 +7,11 @@ none	N	A "quoted" point
 # quote in an item name:
 entity	T"2	Entity with quoted name
 
-# backslashes: stray ones become literal, \n stays a line break:
-entity	B	Dir C:\tmp\nnext line
+# backslashes: \\ renders one literal backslash, \n is a line break:
+entity	B	Dir C:\\hello\nnext line
 
-# backslash-quote combination:
-entity	Q	label with \" should work
+# backslash-quote combination (\\ then "):
+entity	Q	label with \\" should work
 
 # quotes in connection labels:
 P --> T	data with "quotes"

--- a/tests/non-regression/072-label-quotes.dfd
+++ b/tests/non-regression/072-label-quotes.dfd
@@ -13,6 +13,9 @@ entity	B	Dir C:\\hello\nnext line
 # backslash-quote combination (\\ then "):
 entity	Q	label with \\" should work
 
+# */ must not close the generated source-echo comment prematurely:
+entity	C	label with */ inside
+
 # quotes in connection labels:
 P --> T	data with "quotes"
 T"2 --> P	more "data"

--- a/tests/non-regression/072-label-quotes.dfd
+++ b/tests/non-regression/072-label-quotes.dfd
@@ -1,0 +1,22 @@
+# quotes in plain-label item texts:
+process	P	A "quoted" process
+control	K	A "quoted" control
+entity	T	A "quoted" entity
+none	N	A "quoted" point
+
+# quote in an item name:
+entity	T"2	Entity with quoted name
+
+# backslashes: stray ones become literal, \n stays a line break:
+entity	B	Dir C:\tmp\nnext line
+
+# backslash-quote combination:
+entity	Q	label with \" should work
+
+# quotes in connection labels:
+P --> T	data with "quotes"
+T"2 --> P	more "data"
+K ::> N	signal with "quotes"
+
+# quote in a frame label:
+frame P K = A "quoted" frame

--- a/tests/non-regression/072-label-quotes.dot
+++ b/tests/non-regression/072-label-quotes.dot
@@ -1,0 +1,46 @@
+
+digraph D {
+  graph[label="
+- tests/non-regression/072-label-quotes -" fontname="helvetica" fontsize=9 fontcolor="#000060"]
+  rankdir=LR
+  edge[color=gray fontname="times-italic" fontsize=10]
+  node[fontname="helvetica" fontsize=10]
+
+  /* 1: process P A "quoted" process */
+  "P" [shape=ellipse label="A \"quoted\" process" fillcolor="#eeeeee" style=filled ]
+
+  /* 2: control K A "quoted" control */
+  "K" [shape=ellipse label="A \"quoted\" control" fillcolor="#eeeeee" style="filled,dashed" ]
+
+  /* 3: entity T A "quoted" entity */
+  "T" [shape=rectangle label="A \"quoted\" entity" ]
+
+  /* 4: none N A "quoted" point */
+  "N" [shape=none label="A \"quoted\" point" ]
+
+  /* 7: entity T"2 Entity with quoted name */
+  "T\"2" [shape=rectangle label="Entity with quoted\nname" ]
+
+  /* 10: entity B Dir C:\tmp\nnext line */
+  "B" [shape=rectangle label="Dir C:\\tmp\nnext line" ]
+
+  /* 13: entity Q label with \" should work */
+  "Q" [shape=rectangle label="label with \\\" should\nwork" ]
+
+  /* 16: flow P T data with "quotes" */
+  "P" -> "T" [label="data with\n\"quotes\""]
+
+  /* 17: flow T"2 P more "data" */
+  "T\"2" -> "P" [label="more \"data\""]
+
+  /* 18: signal K N signal with "quotes" */
+  "K" -> "N" [label="signal with\n\"quotes\"" style=dashed]
+
+  /* 21: frame P K = A "quoted" frame */
+  subgraph cluster_0 {
+    label="A \"quoted\" frame"
+    style=dashed
+    "P"
+    "K"
+  }
+}

--- a/tests/non-regression/072-label-quotes.dot
+++ b/tests/non-regression/072-label-quotes.dot
@@ -21,11 +21,11 @@ digraph D {
   /* 7: entity T"2 Entity with quoted name */
   "T\"2" [shape=rectangle label="Entity with quoted\nname" ]
 
-  /* 10: entity B Dir C:\tmp\nnext line */
-  "B" [shape=rectangle label="Dir C:\\tmp\nnext line" ]
+  /* 10: entity B Dir C:\\hello\nnext line */
+  "B" [shape=rectangle label="Dir C:\\hello\nnext line" ]
 
-  /* 13: entity Q label with \" should work */
-  "Q" [shape=rectangle label="label with \\\" should\nwork" ]
+  /* 13: entity Q label with \\" should work */
+  "Q" [shape=rectangle label="label with \\\"\nshould work" ]
 
   /* 16: flow P T data with "quotes" */
   "P" -> "T" [label="data with\n\"quotes\""]

--- a/tests/non-regression/072-label-quotes.dot
+++ b/tests/non-regression/072-label-quotes.dot
@@ -27,16 +27,19 @@ digraph D {
   /* 13: entity Q label with \\" should work */
   "Q" [shape=rectangle label="label with \\\"\nshould work" ]
 
-  /* 16: flow P T data with "quotes" */
+  /* 16: entity C label with * / inside */
+  "C" [shape=rectangle label="label with */ inside" ]
+
+  /* 19: flow P T data with "quotes" */
   "P" -> "T" [label="data with\n\"quotes\""]
 
-  /* 17: flow T"2 P more "data" */
+  /* 20: flow T"2 P more "data" */
   "T\"2" -> "P" [label="more \"data\""]
 
-  /* 18: signal K N signal with "quotes" */
+  /* 21: signal K N signal with "quotes" */
   "K" -> "N" [label="signal with\n\"quotes\"" style=dashed]
 
-  /* 21: frame P K = A "quoted" frame */
+  /* 24: frame P K = A "quoted" frame */
   subgraph cluster_0 {
     label="A \"quoted\" frame"
     style=dashed

--- a/tests/non-regression/073-label-html.dfd
+++ b/tests/non-regression/073-label-html.dfd
@@ -1,5 +1,5 @@
 # HTML-special characters in HTML-like labels (store, channel):
-store	S	Store a < b & c > d
+store	S	Store a < b & c > d \\ e
 channel	C	Channel x <y> & "z"
 
 process	P	A process

--- a/tests/non-regression/073-label-html.dfd
+++ b/tests/non-regression/073-label-html.dfd
@@ -1,0 +1,8 @@
+# HTML-special characters in HTML-like labels (store, channel):
+store	S	Store a < b & c > d
+channel	C	Channel x <y> & "z"
+
+process	P	A process
+
+P --> S	write
+C --> P	read

--- a/tests/non-regression/073-label-html.dot
+++ b/tests/non-regression/073-label-html.dot
@@ -6,11 +6,11 @@ digraph D {
   edge[color=gray fontname="times-italic" fontsize=10]
   node[fontname="helvetica" fontsize=10]
 
-  /* 1: store S Store a < b & c > d */
+  /* 1: store S Store a < b & c > d \\ e */
   "S" [shape=none label=<
     <TABLE BORDER="0">
       <TR><TD BGCOLOR="black" WIDTH="6"></TD></TR>
-      <TR><TD><FONT COLOR="black">Store a &lt; b &amp; c &gt; d</FONT></TD></TR>
+      <TR><TD><FONT COLOR="black">Store a &lt; b &amp; c &gt; d<br/>\ e</FONT></TD></TR>
       <TR><TD BGCOLOR="black" WIDTH="6"></TD></TR>
     </TABLE>>]
 

--- a/tests/non-regression/073-label-html.dot
+++ b/tests/non-regression/073-label-html.dot
@@ -1,0 +1,38 @@
+
+digraph D {
+  graph[label="
+- tests/non-regression/073-label-html -" fontname="helvetica" fontsize=9 fontcolor="#000060"]
+  rankdir=LR
+  edge[color=gray fontname="times-italic" fontsize=10]
+  node[fontname="helvetica" fontsize=10]
+
+  /* 1: store S Store a < b & c > d */
+  "S" [shape=none label=<
+    <TABLE BORDER="0">
+      <TR><TD BGCOLOR="black" WIDTH="6"></TD></TR>
+      <TR><TD><FONT COLOR="black">Store a &lt; b &amp; c &gt; d</FONT></TD></TR>
+      <TR><TD BGCOLOR="black" WIDTH="6"></TD></TR>
+    </TABLE>>]
+
+  /* 2: channel C Channel x <y> & "z" */
+  "C" [shape=none label=<
+    <TABLE BORDER="0">
+      <TR>
+        <TD WIDTH="48"></TD>
+        <TD BGCOLOR="black" WIDTH="0" PORT="x"><BR/><BR/></TD>
+        <TD WIDTH="48"></TD>
+      </TR>
+      <TR>
+        <TD COLSPAN="3"><FONT COLOR="black">Channel x &lt;y&gt; &amp; &quot;z&quot;</FONT></TD>
+      </TR>
+    </TABLE>>]
+
+  /* 4: process P A process */
+  "P" [shape=ellipse label="A process" fillcolor="#eeeeee" style=filled ]
+
+  /* 6: flow P S write */
+  "P" -> "S" [label="write"]
+
+  /* 7: flow C P read */
+  "C":x:c -> "P" [label="read"]
+}

--- a/tests/non-regression/074-err-stray-backslash.dfd
+++ b/tests/non-regression/074-err-stray-backslash.dfd
@@ -1,0 +1,2 @@
+# a backslash not starting a recognized escape (\n \l \r \\) is an error:
+process	P	Dir C:\hello

--- a/tests/non-regression/074-err-stray-backslash.stderr
+++ b/tests/non-regression/074-err-stray-backslash.stderr
@@ -1,0 +1,4 @@
+ERROR: (most recent first)
+  line 2: process P Dir C:\hello
+  line 1: <file:tests/non-regression/074-err-stray-backslash.dfd>
+Error: Stray backslash in "Dir C:\hello"; use \\ for a literal backslash, \n for a line break

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -70,6 +70,10 @@ CHECK_ERROR_CASES = [
         id="empty-frame",  # frame with no item names
     ),
     pytest.param(
+        r"process  P  Dir C:\hello",
+        id="stray-backslash",  # backslash not starting a recognized escape
+    ),
+    pytest.param(
         """
         process  P  Proc
         frame UNKNOWN = Title

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -94,14 +94,21 @@ class TestBuild:
         )
         assert 'My \\"Diagram\\"' in dot_text
 
-    def test_label_backslash_escaping(self) -> None:
-        # stray backslashes are escaped; \n label escapes are forwarded
+    def test_label_backslash_escapes_forwarded(self) -> None:
+        # recognized escapes (\\, \n) pass through to Graphviz untouched
         provenance = _src("<test>")
         options = _default_options()
         dot_text, _ = dfd.build(
-            provenance, r"process P Dir C:\tmp\nnext", "", options
+            provenance, r"process P Dir C:\\hello\nnext", "", options
         )
-        assert r'label="Dir C:\\tmp\nnext"' in dot_text
+        assert r'label="Dir C:\\hello\nnext"' in dot_text
+
+    def test_label_stray_backslash_raises(self) -> None:
+        # a backslash not starting a recognized escape is an error
+        provenance = _src("<test>")
+        options = _default_options()
+        with pytest.raises(exception.DfdException, match="Stray backslash"):
+            dfd.build(provenance, r"process P Dir C:\hello", "", options)
 
     def test_empty_title(self) -> None:
         # Empty title (e.g. stdout output) should not crash

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -85,6 +85,24 @@ class TestBuild:
         )
         assert "ShouldNotAppear" not in dot_text
 
+    def test_title_with_quotes_is_escaped(self) -> None:
+        # A title containing double quotes must be escaped in the DOT output
+        provenance = _src("<test>")
+        options = _default_options()
+        dot_text, _ = dfd.build(
+            provenance, "process P Process", 'My "Diagram"', options
+        )
+        assert 'My \\"Diagram\\"' in dot_text
+
+    def test_label_backslash_escaping(self) -> None:
+        # stray backslashes are escaped; \n label escapes are forwarded
+        provenance = _src("<test>")
+        options = _default_options()
+        dot_text, _ = dfd.build(
+            provenance, r"process P Dir C:\tmp\nnext", "", options
+        )
+        assert r'label="Dir C:\\tmp\nnext"' in dot_text
+
     def test_empty_title(self) -> None:
         # Empty title (e.g. stdout output) should not crash
         provenance = _src("<test>")


### PR DESCRIPTION
Fixes #67: any label (or item name) containing a double quote produced invalid DOT and crashed rendering.

**Escaping, per DOT emission context:**

- [x] Double-quoted strings (item names + labels, edge endpoints + labels, frame labels + member refs, graph title): `"` → `\"`
- [x] HTML-like labels (store, channel): HTML-entity escaping (`&`, `<`, `>`), with `\\` → `\` and `\n` → `<br/>` translated
- [x] `*/` broken in DOT source-echo comments

**Backslash rule (agreed during specification):** labels form a small escape language — `\n` line break (documented), `\\` literal backslash, `\l`/`\r` reserved for #59. Any other backslash is rejected at check time with `Stray backslash in "..."; use \\ for a literal backslash, \n for a line break`. So `C:\hello` errors; `C:\\hello` renders `C:\hello`. Documented in `doc/README.md`.

**Verification:**

- [x] New NR fixtures: `072-label-quotes` (quotes in all plain-label item types, item name, edge, frame; `\\`/`\n` cases), `073-label-html`, `074-err-stray-backslash` (error fixture)
- [x] 4 new unit/robustness tests (title quoting, escape forwarding, stray-backslash error ×2)
- [x] All 77 pre-existing goldens byte-identical
- [x] Mutation smoke-tests: each escaping/validation path disabled → corresponding fixtures fail → reverted
- [x] `make black`, `make lint`, `make test` pass (81 NR + 64 pytest)
- [x] Version bump to 1.16.9

Devlog: [devlog/067-escape-dot-labels.md](https://github.com/pbauermeister/dfd/blob/fix/67-escape-dot-labels/devlog/067-escape-dot-labels.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)