### PR TITLE
Feature #69: style statements for text sizes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+## Version 1.17.0:
+
+- Add style statements:
+  - `style item-text-size N`
+  - `style connection-text-size N`
+  - `style graph-title-size N`
+
 ## Version 1.16.9:
 
 - Fix #67: labels containing double quotes produced invalid DOT and crashed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,7 +190,10 @@ Full rules are in **`doc/COMMENTING.md`**. Key points:
 
 Versions follow `MAJOR.MINOR.PATCH` with an optional `.postN` suffix:
 
-- Bump `PATCH` for user-facing changes: bug fixes, new features, doc additions.
+- Bump `MINOR` for new features (even minor ones), as long as they are
+  non-breaking.
+- Bump `PATCH` for bug fixes, refactorings, doc additions, build and
+  tooling changes, tests, and deployment changes.
 - Use `.postN` only for publishing/packaging fixes and trivial wording corrections
   (e.g. fixing a typo in `README.md`, a broken PyPI upload, a CI script tweak)
   that do not affect the tool's behaviour or documentation content.

--- a/devlog/069-style-text-sizes.md
+++ b/devlog/069-style-text-sizes.md
@@ -1,0 +1,69 @@
+# 069 — Style Statements for Text Sizes
+
+Date: 2026-09-03
+
+Status: ONGOING
+
+## Requirement
+
+Add three new `style` statements to control text sizes in the generated
+diagram, complementing the existing `*-text-width` wrapping options:
+
+- `style item-text-size N` — item label text size (default 10)
+- `style connection-text-size N` — connection label text size (default 10)
+- `style graph-title-size N` — graph title text size (default 9)
+
+Constraints and decisions:
+
+- Defaults match the previously hardcoded `fontsize` values in the DOT
+  templates, so existing diagrams render identically (non-breaking).
+- Non-integer values raise a `DfdException` with source context, like the
+  existing width options.
+- Documentation (`doc/README.md`, `doc/SYNTAX.md`) and `CHANGES.md` updated.
+- Version bumps to **1.17.0** — MINOR, per user decision: new non-breaking
+  features warrant a MINOR bump (not just PATCH).
+- The implementation was hand-written by the user; the agent handles review
+  fixes, NR fixtures, and workflow.
+
+## Design
+
+The hand-written implementation (already done, committed as-is on this
+branch):
+
+- `config.py`: `DEFAULT_ITEM_TEXT_SIZE`, `DEFAULT_CONNECTION_TEXT_SIZE`,
+  `DEFAULT_GRAPH_TITLE_SIZE` constants.
+- `model.py`: three new `StyleOption` members and `GraphOptions` fields.
+- `dfd.py`: three new `match` cases in `handle_options`; new `get_style_int()`
+  helper deduplicating the int-parsing try/except (also adopted by the
+  existing width options; fixes a stray `"` in the old error message).
+- `rendering/templates.py`: `DOT_FONT_EDGE` / `DOT_FONT_NODE` /
+  `DOT_FONT_GRAPH` hardcoded `fontsize` values become format placeholders.
+- `rendering/dot.py`: passes the three sizes when formatting templates.
+- Docs: new rows in the style tables of `doc/README.md` and `doc/SYNTAX.md`.
+
+Review findings to fix on the branch:
+
+1. **`DOT_GRAPH_NOTITLE` placeholder leak**: it is appended in
+   `dot.py` without `.format()`, so with `style no-graph-title` the DOT
+   output contains the literal `fontsize={graph_title_size}`. Fix: format it
+   with `graph_title_size` at the point of use.
+2. **Unused import**: `from typing import Any` in `dfd.py`.
+
+### Implementation steps
+
+1. Commit the user's hand-written implementation as-is.
+2. Fix review findings (1) and (2) above.
+3. Create NR fixtures:
+   - `075-style-text-sizes.dfd` + `.dot`: all three sizes set to
+     non-default values, default (titled) graph — exercises
+     `DOT_GRAPH_TITLE`, `DOT_FONT_EDGE`, `DOT_FONT_NODE`.
+   - `076-style-text-sizes-no-title.dfd` + `.dot`: sizes set with
+     `style no-graph-title` — exercises the `DOT_GRAPH_NOTITLE` path
+     (regression guard for finding 1).
+   - Error path (non-integer value) is already covered by
+     `066-err-bad-style-int`.
+   - `make nr-review` → inspect → `make nr-regenerate` → commit fixtures and
+     golden files together.
+4. Mutation smoke-test: mutate the size plumbing (e.g. ignore
+   `item_text_size`), confirm the new fixtures fail, revert.
+5. `make black`, `make lint`, `make test`; update PR body; mark PR ready.

--- a/devlog/069-style-text-sizes.md
+++ b/devlog/069-style-text-sizes.md
@@ -2,7 +2,7 @@
 
 Date: 2026-09-03
 
-Status: ONGOING
+Status: DONE
 
 ## Requirement
 

--- a/devlog/069-style-text-sizes.md
+++ b/devlog/069-style-text-sizes.md
@@ -67,3 +67,29 @@ Review findings to fix on the branch:
 4. Mutation smoke-test: mutate the size plumbing (e.g. ignore
    `item_text_size`), confirm the new fixtures fail, revert.
 5. `make black`, `make lint`, `make test`; update PR body; mark PR ready.
+
+## Outcome
+
+All implementation steps completed as designed; PR #70 green and ready.
+
+- The hand-written implementation was committed as-is, then both review
+  findings were fixed:
+  - `DOT_GRAPH_NOTITLE` placeholder leak — reproduced first (with
+    `style no-graph-title`, the DOT output literally contained
+    `fontsize={graph_title_size}`), fixed by formatting at the point of
+    use, then verified via CLI.
+  - Unused `typing.Any` import removed.
+- NR fixtures added: `075-style-text-sizes` (titled graph, all three sizes
+  at non-default values 14/12/16) and `076-style-text-sizes-no-title`
+  (regression guard for the `DOT_GRAPH_NOTITLE` path). The
+  `066-err-bad-style-int` golden was regenerated: `get_style_int()`
+  dropped a stray trailing `"` from the old error message.
+- Mutation smoke-tests behaved exactly as designed: hardcoding
+  `item_text_size` failed 075+076; hardcoding the no-title
+  `graph_title_size` failed 076 only.
+- `make black`, `make lint`, `make test` all green (64 pytest + 83 NR);
+  CI green on the final commit.
+- Side effect: the CLAUDE.md versioning convention was amended (user
+  decision): MINOR for new non-breaking features; PATCH for bug fixes,
+  refactorings, doc, build/tooling, tests, deployment. The 1.17.0 bump
+  conforms.

--- a/doc/README.md
+++ b/doc/README.md
@@ -227,10 +227,13 @@ diagram:
 | ------------------------------- | --------------------------------------------------------------------------------- |
 | `style background-color COLOR`  | Sets a graph background color as per https://graphviz.org/docs/attr-types/color/. |
 | `style connection-text-width N` | Sets the connections labels wrapping to use N chars columns.                      |
+| `style connection-text-size N`  | Sets the connection label text size                                               |
 | `style context`                 | Makes the diagram a context diagram.                                              |
 | `style horizontal`              | Layouts flows in the horizontal direction (the default).                          |
 | `style item-text-width N`       | Sets the items labels wrapping to use N chars columns.                            |
+| `style item-text-size N`        | Sets the items label text size                                                    |
 | `style no-graph-title`          | Suppress graph title containing the image file path (without extension).          |
+| `style graph-title-size N`      | Sets the graph title text size                                                    |
 | `style rotated`                 | Rotates the diagram by 90°.                                                       |
 | `style unrotated`               | Reverts the diagram rotation, if any.                                             |
 | `style vertical`                | Layouts flows in the vertical direction.                                          |

--- a/doc/SYNTAX.md
+++ b/doc/SYNTAX.md
@@ -14,48 +14,48 @@ documentation, and commit messages.
 
 ### Core concepts
 
-| Term           | Definition                                                        |
-| -------------- | ----------------------------------------------------------------- |
-| **statement**  | A single logical line of DFD source (after preprocessing).        |
+| Term           | Definition                                                                  |
+| -------------- | --------------------------------------------------------------------------- |
+| **statement**  | A single logical line of DFD source (after preprocessing).                  |
 | **item**       | A node in the diagram. Never use "node" in prose — that is a Graphviz term. |
-| **connection** | A directed or undirected link between two items.                  |
-| **endpoint**   | The source or destination item of a connection (`SRC` / `DST`).   |
-| **frame**      | A visual grouping (subgraph) of items.                            |
-| **name**       | The unique identifier of an item (no whitespace).                 |
-| **label**      | The display text of an item or connection. Defaults to the name.  |
+| **connection** | A directed or undirected link between two items.                            |
+| **endpoint**   | The source or destination item of a connection (`SRC` / `DST`).             |
+| **frame**      | A visual grouping (subgraph) of items.                                      |
+| **name**       | The unique identifier of an item (no whitespace).                           |
+| **label**      | The display text of an item or connection. Defaults to the name.            |
 
 ### Item types
 
-| Term        | Definition                                                         |
-| ----------- | ------------------------------------------------------------------ |
-| **process** | A functional unit that processes inputs and generates outputs.      |
-| **entity**  | An external actor, outside the scope of the model.                 |
-| **store**   | Holds data.                                                        |
-| **channel** | Alters the course of flows (data or timing). APIs are channels.    |
-| **control** | Receives and emits signals exclusively (SA/RT).                    |
-| **none**    | A generic point, e.g. repeated from an upper level.                |
+| Term        | Definition                                                      |
+| ----------- | --------------------------------------------------------------- |
+| **process** | A functional unit that processes inputs and generates outputs.  |
+| **entity**  | An external actor, outside the scope of the model.              |
+| **store**   | Holds data.                                                     |
+| **channel** | Alters the course of flows (data or timing). APIs are channels. |
+| **control** | Receives and emits signals exclusively (SA/RT).                 |
+| **none**    | A generic point, e.g. repeated from an upper level.             |
 
 ### Connection types
 
-| Term           | Definition                                         |
-| -------------- | -------------------------------------------------- |
-| **flow**       | Directed data flow.                                |
-| **cflow**      | Continuous (streaming) flow.                       |
-| **bflow**      | Bidirectional flow.                                |
-| **uflow**      | Undirected flow (no arrowheads).                   |
-| **signal**     | Directed signal (SA/RT events).                    |
-| **constraint** | Invisible layout constraint (not a data flow).     |
+| Term           | Definition                                     |
+| -------------- | ---------------------------------------------- |
+| **flow**       | Directed data flow.                            |
+| **cflow**      | Continuous (streaming) flow.                   |
+| **bflow**      | Bidirectional flow.                            |
+| **uflow**      | Undirected flow (no arrowheads).               |
+| **signal**     | Directed signal (SA/RT events).                |
+| **constraint** | Invisible layout constraint (not a data flow). |
 
 ### Modifiers
 
-| Term                  | Definition                                                              |
-| --------------------- | ----------------------------------------------------------------------- |
-| **reversed** (`.r`)   | Connection whose rendering direction is swapped.                        |
-| **relaxed** (`?`)     | Connection that does not impose a layout constraint.                    |
+| Term                  | Definition                                                                 |
+| --------------------- | -------------------------------------------------------------------------- |
+| **reversed** (`.r`)   | Connection whose rendering direction is swapped.                           |
+| **relaxed** (`?`)     | Connection that does not impose a layout constraint.                       |
 | **hidable** (`?`)     | Item hidden from the diagram unless at least one connection references it. |
-| **external item**     | Item referencing another graph via the dependency syntax (`GRAPH:NAME`). |
-| **inline attributes** | Graphviz attributes in brackets prefixing a label (`[ATTRS]`).          |
-| **attribute alias**   | A reusable name for a set of Graphviz attributes (`attrib`).            |
+| **external item**     | Item referencing another graph via the dependency syntax (`GRAPH:NAME`).   |
+| **inline attributes** | Graphviz attributes in brackets prefixing a label (`[ATTRS]`).             |
+| **attribute alias**   | A reusable name for a set of Graphviz attributes (`attrib`).               |
 
 ### Including
 
@@ -68,28 +68,28 @@ documentation, and commit messages.
 
 ### Dependencies
 
-| Term           | Definition                                                          |
-| -------------- | ------------------------------------------------------------------- |
+| Term           | Definition                                                                   |
+| -------------- | ---------------------------------------------------------------------------- |
 | **dependency** | A reference from one graph to an item (or the whole graph) of another graph. |
 
 ### Filters
 
-| Term                       | Definition                                                                |
-| -------------------------- | ------------------------------------------------------------------------- |
-| **filter**                 | A statement (`!` or `~`) that manipulates the kept set.                   |
-| **Only filter** (`!`)      | Additive: adds items to the kept set.                                     |
-| **Without filter** (`~`)   | Subtractive: removes items from the kept set.                             |
-| **kept set**               | The set of item names retained after all filters have been processed.     |
-| **anchor**                 | An item explicitly listed in a filter (as opposed to its neighbors). Called "listed items" in `doc/README.md`. |
-| **neighbor**              | An item reachable from an anchor by traversing connections.               |
-| **upstream**               | Toward the source of a flow.                                              |
-| **downstream**             | Toward the destination of a flow.                                         |
-| **left** / **right**       | Layout-based direction (as rendered by Graphviz), orthogonal to the flow. |
-| **direction**              | Upstream, downstream, left, or right.                                     |
-| **span**                   | How many levels of neighbors to traverse (`*` = unlimited, or integer).  |
-| **"x" flag**               | Suppress anchors: select only neighbors, not the listed items themselves. |
-| **"f" flag**               | Suppress frames: remove frames involving the selected items.              |
-| **replacement**            | An item that takes over connections from removed items (`=NAME` in Without). |
+| Term                     | Definition                                                                                                     |
+| ------------------------ | -------------------------------------------------------------------------------------------------------------- |
+| **filter**               | A statement (`!` or `~`) that manipulates the kept set.                                                        |
+| **Only filter** (`!`)    | Additive: adds items to the kept set.                                                                          |
+| **Without filter** (`~`) | Subtractive: removes items from the kept set.                                                                  |
+| **kept set**             | The set of item names retained after all filters have been processed.                                          |
+| **anchor**               | An item explicitly listed in a filter (as opposed to its neighbors). Called "listed items" in `doc/README.md`. |
+| **neighbor**             | An item reachable from an anchor by traversing connections.                                                    |
+| **upstream**             | Toward the source of a flow.                                                                                   |
+| **downstream**           | Toward the destination of a flow.                                                                              |
+| **left** / **right**     | Layout-based direction (as rendered by Graphviz), orthogonal to the flow.                                      |
+| **direction**            | Upstream, downstream, left, or right.                                                                          |
+| **span**                 | How many levels of neighbors to traverse (`*` = unlimited, or integer).                                        |
+| **"x" flag**             | Suppress anchors: select only neighbors, not the listed items themselves.                                      |
+| **"f" flag**             | Suppress frames: remove frames involving the selected items.                                                   |
+| **replacement**          | An item that takes over connections from removed items (`=NAME` in Without).                                   |
 
 ## Overview
 
@@ -139,21 +139,21 @@ ITEM_TYPE GRAPH:NAME [LABEL]
 CONN_TYPE SRC DST [LABEL]
 ```
 
-| Token       | Values                                                             |
-| ----------- | ------------------------------------------------------------------ |
-| `CONN_TYPE` | `flow`, `cflow`, `bflow`, `uflow`, `signal`, `constraint`         |
+| Token       | Values                                                                       |
+| ----------- | ---------------------------------------------------------------------------- |
+| `CONN_TYPE` | `flow`, `cflow`, `bflow`, `uflow`, `signal`, `constraint`                    |
 | `SRC`/`DST` | Item name (endpoint), or `*` for an anonymous endpoint (generates a `none`). |
-| `LABEL`     | Optional free text. May start with `[ATTRS]`.                      |
+| `LABEL`     | Optional free text. May start with `[ATTRS]`.                                |
 
 ### Variants
 
 Keyword variants encode direction and constraint behaviour:
 
-| Suffix | Meaning                              | Example          |
-| ------ | ------------------------------------ | ---------------- |
-| `.r`   | Reversed (swap src/dst in rendering) | `flow.r`         |
-| `?`    | Relaxed (no layout constraint)       | `flow?`          |
-| `.r?`  | Both reversed and relaxed            | `flow.r?`        |
+| Suffix | Meaning                              | Example   |
+| ------ | ------------------------------------ | --------- |
+| `.r`   | Reversed (swap src/dst in rendering) | `flow.r`  |
+| `?`    | Relaxed (no layout constraint)       | `flow?`   |
+| `.r?`  | Both reversed and relaxed            | `flow.r?` |
 
 Not all combinations exist for all types. See `model.Keyword` for the
 full enumeration.
@@ -166,18 +166,18 @@ SRC ARROW DST [LABEL]
 
 Arrows are rewritten to keyword form before parsing:
 
-| Arrow pattern | Keyword equivalent | Notes                    |
-| ------------- | ------------------ | ------------------------ |
-| `-->`         | `flow`             | Shaft of any length      |
-| `<--`         | `flow.r`           | Reversed                 |
-| `->>`         | `cflow`            | Continuous flow           |
-| `<<-`         | `cflow.r`          | Reversed                 |
-| `<->`         | `bflow`            | Bidirectional            |
-| `---`         | `uflow`            | Undirected               |
-| `::>`         | `signal`           | Signal                   |
-| `<::`         | `signal.r`         | Reversed signal          |
-| `>>`          | `constraint`       | Layout constraint        |
-| `<<`          | `constraint.r`     | Reversed constraint      |
+| Arrow pattern | Keyword equivalent | Notes               |
+| ------------- | ------------------ | ------------------- |
+| `-->`         | `flow`             | Shaft of any length |
+| `<--`         | `flow.r`           | Reversed            |
+| `->>`         | `cflow`            | Continuous flow     |
+| `<<-`         | `cflow.r`          | Reversed            |
+| `<->`         | `bflow`            | Bidirectional       |
+| `---`         | `uflow`            | Undirected          |
+| `::>`         | `signal`           | Signal              |
+| `<::`         | `signal.r`         | Reversed signal     |
+| `>>`          | `constraint`       | Layout constraint   |
+| `<<`          | `constraint.r`     | Reversed constraint |
 
 Appending `?` to any arrow (e.g. `-->?`) produces the relaxed variant.
 The shaft (`-`, `:`) can be of arbitrary length.
@@ -198,17 +198,20 @@ one frame.
 style OPTION [VALUE]
 ```
 
-| Option                  | Value    | Effect                             |
-| ----------------------- | -------- | ---------------------------------- |
-| `horizontal`            | -        | Left-to-right layout (default)     |
-| `vertical`              | -        | Top-to-bottom layout               |
-| `context`               | -        | Context diagram mode               |
-| `rotated`               | -        | Rotate diagram 90 degrees          |
-| `unrotated`             | -        | Cancel rotation                    |
-| `item-text-width`       | integer  | Item label wrap width (default 20) |
-| `connection-text-width` | integer  | Connection label wrap width (14)   |
-| `background-color`      | color    | Graphviz color spec                |
-| `no-graph-title`        | -        | Suppress auto-generated title      |
+| Option                  | Value   | Effect                             |
+| ----------------------- | ------- | ---------------------------------- |
+| `horizontal`            | -       | Left-to-right layout (default)     |
+| `vertical`              | -       | Top-to-bottom layout               |
+| `context`               | -       | Context diagram mode               |
+| `rotated`               | -       | Rotate diagram 90 degrees          |
+| `unrotated`             | -       | Cancel rotation                    |
+| `item-text-width`       | integer | Item label wrap width (default 20) |
+| `item-text-size`        | integer | Item label text size (default 10)  |
+| `connection-text-width` | integer | Connection label wrap width (14)   |
+| `connection-text-size`  | integer | Connection label text size (10)    |
+| `background-color`      | color   | Graphviz color spec                |
+| `no-graph-title`        | -       | Suppress auto-generated title      |
+| `graph-title-size`      | integer | Graph title text size (default 9)  |
 
 Styles apply globally. Last declaration wins if redefined.
 
@@ -264,11 +267,11 @@ replacement item instead of discarding them.
 DIRECTION[FLAGS]SPAN
 ```
 
-| Part        | Values                                           |
-| ----------- | ------------------------------------------------ |
-| `DIRECTION` | `>` downstream, `<` upstream, `<>` both, `[` left, `]` right |
+| Part        | Values                                                         |
+| ----------- | -------------------------------------------------------------- |
+| `DIRECTION` | `>` downstream, `<` upstream, `<>` both, `[` left, `]` right   |
 | `FLAGS`     | `x` = suppress anchors (neighbors only), `f` = suppress frames |
-| `SPAN`      | `*` = unlimited, or integer distance              |
+| `SPAN`      | `*` = unlimited, or integer distance                           |
 
 Examples: `>*` (all downstream), `<>2` (two levels in both directions),
 `<>xf2` (two levels, neighbors only, suppress frames).

--- a/src/data_flow_diagram/config.py
+++ b/src/data_flow_diagram/config.py
@@ -3,6 +3,10 @@
 DEFAULT_ITEM_TEXT_WIDTH = 20
 DEFAULT_CONNECTION_TEXT_WIDTH = 14
 
+DEFAULT_CONNECTION_TEXT_SIZE = 10
+DEFAULT_ITEM_TEXT_SIZE = 10
+DEFAULT_GRAPH_TITLE_SIZE = 9
+
 # Default Graphviz attributes applied during parsing
 
 ITEM_EXTERNAL_ATTRS = "fillcolor=white color=grey fontcolor=grey"

--- a/src/data_flow_diagram/dfd.py
+++ b/src/data_flow_diagram/dfd.py
@@ -1,7 +1,5 @@
 """Pipeline orchestrator: scan → parse → check → resolve → filter → render."""
 
-from typing import Any
-
 from . import config, exception, model
 from .console import dprint
 from .dsl import checker, dependency_checker, filters, parser, scanner

--- a/src/data_flow_diagram/dfd.py
+++ b/src/data_flow_diagram/dfd.py
@@ -1,5 +1,7 @@
 """Pipeline orchestrator: scan → parse → check → resolve → filter → render."""
 
+from typing import Any
+
 from . import config, exception, model
 from .console import dprint
 from .dsl import checker, dependency_checker, filters, parser, scanner
@@ -111,6 +113,14 @@ def remove_unused_hidables(statements: model.Statements) -> model.Statements:
     return new_statements
 
 
+def get_style_int(statement: model.Style) -> int:
+    """Parse an integer style value and return it, or raise a DfdException."""
+    try:
+        return int(statement.value)
+    except ValueError as e:
+        raise exception.DfdException(f'{e}', source=statement.source) from e
+
+
 def handle_options(
     statements: model.Statements,
 ) -> tuple[model.Statements, model.GraphOptions]:
@@ -132,23 +142,19 @@ def handle_options(
                     case model.StyleOption.UNROTATED:
                         options.is_rotated = False
                     case model.StyleOption.ITEM_TEXT_WIDTH:
-                        try:
-                            options.item_text_width = int(style.value)
-                        except ValueError as e:
-                            raise exception.DfdException(
-                                f'{e}"', source=statement.source
-                            ) from e
+                        options.item_text_width = get_style_int(statement)
                     case model.StyleOption.CONNECTION_TEXT_WIDTH:
-                        try:
-                            options.connection_text_width = int(style.value)
-                        except ValueError as e:
-                            raise exception.DfdException(
-                                f'{e}"', source=statement.source
-                            ) from e
+                        options.connection_text_width = get_style_int(statement)
                     case model.StyleOption.BACKGROUND_COLOR:
                         options.background_color = style.value
                     case model.StyleOption.NO_GRAPH_TITLE:
                         options.no_graph_title = True
+                    case model.StyleOption.CONNECTION_TEXT_SIZE:
+                        options.connection_text_size = get_style_int(statement)
+                    case model.StyleOption.ITEM_TEXT_SIZE:
+                        options.item_text_size = get_style_int(statement)
+                    case model.StyleOption.GRAPH_TITLE_SIZE:
+                        options.graph_title_size = get_style_int(statement)
                     case _:
                         raise exception.DfdException(
                             f'Unsupported style "{style.style}"',

--- a/src/data_flow_diagram/model.py
+++ b/src/data_flow_diagram/model.py
@@ -69,6 +69,9 @@ class GraphOptions:
     connection_text_width: int = config.DEFAULT_CONNECTION_TEXT_WIDTH
     background_color: str | None = None
     no_graph_title: bool = False
+    connection_text_size: int = config.DEFAULT_CONNECTION_TEXT_SIZE
+    item_text_size: int = config.DEFAULT_ITEM_TEXT_SIZE
+    graph_title_size: int = config.DEFAULT_GRAPH_TITLE_SIZE
 
 
 @dataclass
@@ -159,6 +162,9 @@ class StyleOption(StrEnum):
     CONNECTION_TEXT_WIDTH = "connection-text-width"
     BACKGROUND_COLOR = "background-color"
     NO_GRAPH_TITLE = "no-graph-title"
+    CONNECTION_TEXT_SIZE = "connection-text-size"
+    ITEM_TEXT_SIZE = "item-text-size"
+    GRAPH_TITLE_SIZE = "graph-title-size"
 
 
 ##############################################################################

--- a/src/data_flow_diagram/rendering/dot.py
+++ b/src/data_flow_diagram/rendering/dot.py
@@ -281,7 +281,10 @@ class Generator:
         if title:
             escaped_title = _escape_dot_string(title)
             graph_params.append(
-                TMPL.DOT_GRAPH_TITLE.format(title=escaped_title)
+                TMPL.DOT_GRAPH_TITLE.format(
+                    title=escaped_title,
+                    graph_title_size=self.graph_options.graph_title_size,
+                )
             )
         else:
             graph_params.append(TMPL.DOT_GRAPH_NOTITLE)
@@ -303,6 +306,8 @@ class Generator:
             title=title,
             block=block,
             graph_params="\n  ".join(graph_params),
+            connection_text_size=self.graph_options.connection_text_size,
+            item_text_size=self.graph_options.item_text_size,
         ).replace("\n  \n", "\n\n")
         return text
 

--- a/src/data_flow_diagram/rendering/dot.py
+++ b/src/data_flow_diagram/rendering/dot.py
@@ -287,7 +287,11 @@ class Generator:
                 )
             )
         else:
-            graph_params.append(TMPL.DOT_GRAPH_NOTITLE)
+            graph_params.append(
+                TMPL.DOT_GRAPH_NOTITLE.format(
+                    graph_title_size=self.graph_options.graph_title_size
+                )
+            )
 
         if self.graph_options.is_vertical:
             graph_params.append(TMPL.LAYOUT_VERTICAL)

--- a/src/data_flow_diagram/rendering/templates.py
+++ b/src/data_flow_diagram/rendering/templates.py
@@ -77,9 +77,11 @@ CHANNEL_HORIZONTAL = """
 
 
 # Graphviz font defaults for edges, items, and graph label
-DOT_FONT_EDGE = 'fontname="times-italic" fontsize=10'
-DOT_FONT_NODE = 'fontname="helvetica" fontsize=10'
-DOT_FONT_GRAPH = 'fontname="helvetica" fontsize=9 fontcolor="#000060"'
+DOT_FONT_EDGE = 'fontname="times-italic" fontsize={connection_text_size}'
+DOT_FONT_NODE = 'fontname="helvetica" fontsize={item_text_size}'
+DOT_FONT_GRAPH = (
+    'fontname="helvetica" fontsize={graph_title_size} fontcolor="#000060"'
+)
 
 DOT_GRAPH_TITLE = """graph[label="\n- {title} -" """ + DOT_FONT_GRAPH + """]"""
 DOT_GRAPH_NOTITLE = f"graph[{DOT_FONT_GRAPH}]"

--- a/tests/non-regression/066-err-bad-style-int.stderr
+++ b/tests/non-regression/066-err-bad-style-int.stderr
@@ -1,4 +1,4 @@
 ERROR: (most recent first)
   line 1: style item-text-width abc
   line 1: <file:tests/non-regression/066-err-bad-style-int.dfd>
-Error: invalid literal for int() with base 10: 'abc'"
+Error: invalid literal for int() with base 10: 'abc'

--- a/tests/non-regression/075-style-text-sizes.dfd
+++ b/tests/non-regression/075-style-text-sizes.dfd
@@ -1,0 +1,9 @@
+style item-text-size 14
+style connection-text-size 12
+style graph-title-size 16
+
+process	P1
+entity	E1
+store	S1
+E1 --> P1	request
+P1 --> S1	record

--- a/tests/non-regression/075-style-text-sizes.dot
+++ b/tests/non-regression/075-style-text-sizes.dot
@@ -1,0 +1,28 @@
+
+digraph D {
+  graph[label="
+- tests/non-regression/075-style-text-sizes -" fontname="helvetica" fontsize=16 fontcolor="#000060"]
+  rankdir=LR
+  edge[color=gray fontname="times-italic" fontsize=12]
+  node[fontname="helvetica" fontsize=14]
+
+  /* 4: process P1 */
+  "P1" [shape=ellipse label="P1" fillcolor="#eeeeee" style=filled ]
+
+  /* 5: entity E1 */
+  "E1" [shape=rectangle label="E1" ]
+
+  /* 6: store S1 */
+  "S1" [shape=none label=<
+    <TABLE BORDER="0">
+      <TR><TD BGCOLOR="black" WIDTH="6"></TD></TR>
+      <TR><TD><FONT COLOR="black">S1</FONT></TD></TR>
+      <TR><TD BGCOLOR="black" WIDTH="6"></TD></TR>
+    </TABLE>>]
+
+  /* 7: flow E1 P1 request */
+  "E1" -> "P1" [label="request"]
+
+  /* 8: flow P1 S1 record */
+  "P1" -> "S1" [label="record"]
+}

--- a/tests/non-regression/076-style-text-sizes-no-title.dfd
+++ b/tests/non-regression/076-style-text-sizes-no-title.dfd
@@ -1,0 +1,8 @@
+style no-graph-title
+style item-text-size 14
+style connection-text-size 12
+style graph-title-size 16
+
+process	P1
+entity	E1
+E1 --> P1	request

--- a/tests/non-regression/076-style-text-sizes-no-title.dot
+++ b/tests/non-regression/076-style-text-sizes-no-title.dot
@@ -1,0 +1,16 @@
+
+digraph D {
+  graph[fontname="helvetica" fontsize=16 fontcolor="#000060"]
+  rankdir=LR
+  edge[color=gray fontname="times-italic" fontsize=12]
+  node[fontname="helvetica" fontsize=14]
+
+  /* 5: process P1 */
+  "P1" [shape=ellipse label="P1" fillcolor="#eeeeee" style=filled ]
+
+  /* 6: entity E1 */
+  "E1" [shape=rectangle label="E1" ]
+
+  /* 7: flow E1 P1 request */
+  "E1" -> "P1" [label="request"]
+}


### PR DESCRIPTION
Closes #69.

Devlog: [devlog/069-style-text-sizes.md](devlog/069-style-text-sizes.md)

## Summary

Three new `style` statements to control text sizes, complementing the existing `*-text-width` options:

- `style item-text-size N` (default 10)
- `style connection-text-size N` (default 10)
- `style graph-title-size N` (default 9)

Defaults match the previously hardcoded `fontsize` values, so existing diagrams are unaffected (non-breaking). Version bumps to 1.17.0 per the amended versioning convention (MINOR for new non-breaking features).

## Checklist

- [x] Hand-written implementation (config, model, dfd, templates, dot, docs, CHANGES)
- [x] Review fixes: `DOT_GRAPH_NOTITLE` placeholder leak with `style no-graph-title`; unused `typing.Any` import
- [x] NR fixtures 075 (titled) + 076 (no-title regression guard); 066 golden updated (stray quote removed from error message)
- [x] Mutation smoke-test: both mutations caught by the new fixtures
- [x] `make black` / `make lint` / `make test` (64 pytest + 83 NR) all green
- [x] CLAUDE.md versioning convention amended (MINOR for features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)