### PR TITLE
Refactor #71: streamline style option definitions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,12 @@
+## Version 1.17.1:
+
+- Refactor #71: `style` options are now declared in one place (the
+  `GraphOptions` field metadata in `model.py`), from which the keyword
+  registry, the parsing, and the style tables of `doc/README.md` and
+  `doc/SYNTAX.md` are derived. `make readme` regenerates the tables and
+  reformats the docs with prettier; a pytest guards against drift. No
+  behavior change.
+
 ## Version 1.17.0:
 
 - Add style statements:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,9 +1,9 @@
 ## Version 1.17.1:
 
 - Refactor #71: `style` options are now declared in one place (the
-  `GraphOptions` field metadata in `model.py`), from which the keyword
-  registry, the parsing, and the style tables of `doc/README.md` and
-  `doc/SYNTAX.md` are derived. `make readme` regenerates the tables and
+  `GraphOptions` field declarations in `model.py`; default values stay in
+  `config.py`), from which the keyword registry, the parsing, and the style
+  tables of `doc/README.md` and `doc/SYNTAX.md` are derived. `make readme` regenerates the tables and
   reformats the docs with prettier; a pytest guards against drift. No
   behavior change.
 

--- a/Makefile
+++ b/Makefile
@@ -34,13 +34,13 @@ venv-activate: ## activate .venv and start an interactive shell
 _venv:
 	$(PYTHON3) -m venv $(VENV)
 
-require-system: ## install system packages (graphviz, python3-venv)
+require-system: ## install system packages (graphviz, python3-venv, npm)
 	@case "$$(uname -s)" in \
 	  Linux)  which apt >/dev/null 2>&1 && \
-	          sudo apt install -y graphviz python3-venv || \
+	          sudo apt install -y graphviz python3-venv npm || \
 	          echo "Non-Debian Linux: install graphviz manually" ;; \
 	  Darwin) which brew >/dev/null 2>&1 && \
-	          brew install graphviz python3 || \
+	          brew install graphviz python3 node || \
 	          echo "macOS without Homebrew: install graphviz manually" ;; \
 	  *)      echo "Unknown OS: install graphviz manually" ;; \
 	esac
@@ -48,6 +48,7 @@ require-system: ## install system packages (graphviz, python3-venv)
 require: ## install needed dev+install tools, in venv
 	. $(VENV)/bin/activate && \
 	pip install setuptools twine pytest mypy
+	npm install --prefix $(VENV) --no-audit --no-fund prettier@3
 
 all: require-system venv require black lint test doc clean ## make all, except publish
 
@@ -88,9 +89,9 @@ install: ## install locally
 ################################################################################
 # Release:: ##
 
-readme: ## regenerate auto-updatable sections of README.md
+readme: ## regenerate auto-updatable sections of README.md and doc/*.md
 	. $(VENV)/bin/activate && \
-	./tools/update-readme.sh
+	VENV=$(VENV) ./tools/update-docs.sh
 
 doc: readme ## remake doc
 	. $(VENV)/bin/activate && \

--- a/devlog/071-streamline-style-options.md
+++ b/devlog/071-streamline-style-options.md
@@ -2,7 +2,7 @@
 
 Date: 2026-09-03
 
-Status: PENDING
+Status: ONGOING
 
 ## Requirement
 

--- a/devlog/071-streamline-style-options.md
+++ b/devlog/071-streamline-style-options.md
@@ -85,6 +85,12 @@ class GraphOptions:
   and str fields (revised in PR review from a single `style()` helper with
   positional default, so that mandatory arguments are enforced by the
   signature and call sites read explicitly).
+- Metadata is one key (`STYLE_METADATA`) holding a typed declaration
+  object, `StyleFlagsDecl` or `StyleValueDecl`; the registry builder
+  dispatches with `match` on the class. `StyleKind` is an `Enum` (FLAG /
+  INT / STR); `apply_style` and the doc generator match on its members
+  with `assert_never` for exhaustiveness. Both revised in PR review from
+  string-keyed dicts and a `Literal` type, for lint-time checkability.
 - `StyleSpec(field, kind, value, doc)` with `kind` in `flag | int | str`,
   inferred from the resolved type hint (`bool` → flag, `int` → int, else
   str). `value` is the fixed value for flags, the default otherwise.

--- a/devlog/071-streamline-style-options.md
+++ b/devlog/071-streamline-style-options.md
@@ -29,10 +29,14 @@ Decisions taken with the user:
   metadata via a small helper; type and default come from the field itself.
   Everything else is derived: the keyword registry, the generic
   `handle_options`, and the two documentation tables.
-- **Fold the defaults**: the style-related `DEFAULT_*` constants in
-  `config.py` are removed; the field default is the default.
-  `doc/CONVENTIONS.md` is updated accordingly. The `StyleOption` enum is
-  removed (it was referenced only by `handle_options`).
+- **Defaults stay in `config.py`** (revised in PR review: initially
+  folded into the field declarations). The user prefers value tuning in a
+  distinct module; the field default references the constant
+  (`default=config.DEFAULT_ITEM_TEXT_WIDTH`), so the registry and the
+  generated docs still read the value from the field and cannot drift.
+  Adding a valued option thus means two edits (constant + declaration).
+  Flag defaults stay literal. The `StyleOption` enum is removed (it was
+  referenced only by `handle_options`).
 - **One doc string per option**, shared by both tables. `doc/SYNTAX.md`
   derives its "Value" and default columns from the field type and default.
   SYNTAX wording changes slightly as a consequence.
@@ -75,7 +79,12 @@ class GraphOptions:
     ...
 ```
 
-- `style()` wraps `dataclasses.field(default=..., metadata=...)`.
+- Two keyword-only helpers wrap `dataclasses.field(default=..., metadata=...)`:
+  `declare_style_as_flags(default, flags)` for bool fields and
+  `declare_style_as_value(default, name, doc, placeholder="N")` for int
+  and str fields (revised in PR review from a single `style()` helper with
+  positional default, so that mandatory arguments are enforced by the
+  signature and call sites read explicitly).
 - `StyleSpec(field, kind, value, doc)` with `kind` in `flag | int | str`,
   inferred from the resolved type hint (`bool` → flag, `int` → int, else
   str). `value` is the fixed value for flags, the default otherwise.
@@ -127,9 +136,11 @@ extract the marker section, compare to the generator output.
 All steps completed as designed; PR #72 ready for review.
 
 - Adding a style option is now one field declaration in `GraphOptions`
-  followed by `make readme`. Six edit sites in five files became one.
-- `model.style()` wraps `dataclasses.field(metadata=...)`; `STYLE_SPECS`
-  is built at import from the field declarations. Kind is inferred from
+  (plus its default constant in `config.py` for valued options) followed
+  by `make readme`. Six edit sites in five files became one or two.
+- `model.declare_style_as_flags()` / `declare_style_as_value()` wrap
+  `dataclasses.field(metadata=...)`; `STYLE_SPECS` is built at import from
+  the field declarations. Kind is inferred from
   the resolved type hint (`bool` → flag, `int` → int, else str). A
   `placeholder` metadata (default `N`, `COLOR` for `background-color`)
   feeds the value word shown in both tables.

--- a/devlog/071-streamline-style-options.md
+++ b/devlog/071-streamline-style-options.md
@@ -2,7 +2,7 @@
 
 Date: 2026-09-03
 
-Status: ONGOING
+Status: DONE
 
 ## Requirement
 
@@ -121,3 +121,29 @@ extract the marker section, compare to the generator output.
    in the registry, confirm the test fails, revert.
 4. **Wrap-up.** `CHANGES.md` 1.17.1, PR body update, `gh pr ready`.
 5. **Follow-up issue** for CLI flag derivation, opened after merge.
+
+## Outcome
+
+All steps completed as designed; PR #72 ready for review.
+
+- Adding a style option is now one field declaration in `GraphOptions`
+  followed by `make readme`. Six edit sites in five files became one.
+- `model.style()` wraps `dataclasses.field(metadata=...)`; `STYLE_SPECS`
+  is built at import from the field declarations. Kind is inferred from
+  the resolved type hint (`bool` → flag, `int` → int, else str). A
+  `placeholder` metadata (default `N`, `COLOR` for `background-color`)
+  feeds the value word shown in both tables.
+- Declaration order in `GraphOptions` is the doc order; fields were
+  regrouped as layout / text / graph, so both tables changed order.
+- `doc/SYNTAX.md` gained a Default column, derived from the field default.
+- `tools/update-readme.sh` was renamed `tools/update-docs.sh`; the top-level
+  `README.md` and both doc files were already prettier-clean, so prettier
+  is a no-op today and a safety net for later. Prettier lives in
+  `$(VENV)/node_modules`, installed by `make require`; `make require-system`
+  installs `npm` (apt) / `node` (brew). tox and CI do not call
+  `make require`, so CI is unaffected.
+- Drift test `tests/test_doc_sync.py` runs the generator as a subprocess
+  and compares with the marker sections. Mutation smoke-test: altering a doc
+  string and adding a keyword both made it fail; reverted.
+- All 81 NR goldens passed unchanged throughout; 66 pytest.
+- Follow-up: derive CLI flags from the same metadata (separate task).

--- a/devlog/071-streamline-style-options.md
+++ b/devlog/071-streamline-style-options.md
@@ -1,0 +1,123 @@
+# 071 — Streamline Style Options
+
+Date: 2026-09-03
+
+Status: PENDING
+
+## Requirement
+
+From GitHub issue #71: defining a new `style` option requires manual,
+mechanical edits in several places. Make one place the dense source of
+truth (type, default, DSL keyword, explanation) and derive or generate the
+rest.
+
+Audit of the current state: six edit sites in five files per option.
+
+| Site                                     | File            |
+| ---------------------------------------- | --------------- |
+| `DEFAULT_*` constant                     | `config.py`     |
+| `GraphOptions` field                     | `model.py`      |
+| `StyleOption` enum member                | `model.py`      |
+| `match` case in `handle_options`         | `dfd.py`        |
+| Row in the per-diagram style table 2.5.1 | `doc/README.md` |
+| Row in the styles table 4                | `doc/SYNTAX.md` |
+
+Decisions taken with the user:
+
+- **Single source of truth is the `GraphOptions` field declaration.** The
+  DSL keyword(s) and the doc string are attached as `dataclasses.field`
+  metadata via a small helper; type and default come from the field itself.
+  Everything else is derived: the keyword registry, the generic
+  `handle_options`, and the two documentation tables.
+- **Fold the defaults**: the style-related `DEFAULT_*` constants in
+  `config.py` are removed; the field default is the default.
+  `doc/CONVENTIONS.md` is updated accordingly. The `StyleOption` enum is
+  removed (it was referenced only by `handle_options`).
+- **One doc string per option**, shared by both tables. `doc/SYNTAX.md`
+  derives its "Value" and default columns from the field type and default.
+  SYNTAX wording changes slightly as a consequence.
+- **Docs are generated** into `<!-- AUTO:... -->` marker sections of
+  `doc/README.md` and `doc/SYNTAX.md`, reusing the mechanism of
+  `tools/update-readme.sh`, under `make readme` / `make doc`.
+- **After insertion, the doc files are reformatted with prettier** so that
+  manual edits in VSCode (prettier autoformatter) create no meaningless
+  diffs. Both files are already prettier-clean today, so this is a safety
+  net. Prettier is installed by `make require` (into the venv directory via
+  npm, not globally); `make require-system` adds `npm`.
+- **Drift guard is a pytest test**: it regenerates the tables in memory
+  and compares them to the marker sections of both doc files. It needs no
+  Node, so `make test` and CI are unaffected.
+- **Behavior is byte-identical**: DOT output and error messages
+  (`Unsupported style "..."`, `get_style_int` errors) do not change, so the
+  existing 81 NR fixtures are the safety net. No new NR fixtures.
+- **CLI flags stay out of scope.** Deriving `--background-color` /
+  `--no-graph-title` (and possibly more) from the same metadata is a
+  feature with its own product decisions; it becomes a separate task. This
+  task only leaves the door open: the registry exposes name, kind, default,
+  and doc for every option.
+- Refactor: PATCH bump to 1.17.1.
+
+## Design
+
+### Registry (`model.py`)
+
+```python
+@dataclass
+class GraphOptions:
+    is_vertical: bool = style(False, flags={
+        "vertical":   (True,  "Layouts flows in the vertical direction."),
+        "horizontal": (False, "Layouts flows in the horizontal direction (the default)."),
+    })
+    item_text_width: int = style(20, name="item-text-width",
+        doc="Sets the items labels wrapping to use N chars columns.")
+    background_color: str | None = style(None, name="background-color",
+        doc="Sets a graph background color as per https://graphviz.org/docs/attr-types/color/.")
+    ...
+```
+
+- `style()` wraps `dataclasses.field(default=..., metadata=...)`.
+- `StyleSpec(field, kind, value, doc)` with `kind` in `flag | int | str`,
+  inferred from the resolved type hint (`bool` → flag, `int` → int, else
+  str). `value` is the fixed value for flags, the default otherwise.
+- `STYLE_SPECS: dict[str, StyleSpec]` is built once at import from
+  `dataclasses.fields(GraphOptions)` and `typing.get_type_hints`.
+
+### Generic `handle_options` (`dfd.py`)
+
+One registry lookup (unknown keyword → same "Unsupported style" error),
+one three-way branch on `kind` (flag → fixed value, int →
+`get_style_int`, str → raw value), one `setattr`.
+
+### Doc generation (`tools/`)
+
+- `tools/gen-style-tables.py`: imports the model, prints the README table
+  (`Style statement | Effect`) or the SYNTAX table
+  (`Option | Value | Effect`) as padded Markdown, selectable by argument.
+- `tools/update-readme.sh` becomes `tools/update-docs.sh`: `replace_section`
+  takes a file path; new sections `style-table` in `doc/README.md` and
+  `doc/SYNTAX.md`; after replacement, runs
+  `$VENV/node_modules/.bin/prettier --write` on the touched files.
+- Makefile: `require` adds `npm install --prefix $(VENV) prettier@3`;
+  `require-system` adds `npm` to the apt/brew lists; `readme` target calls
+  the renamed script.
+
+### Drift guard (`tests/`)
+
+Integration test (placement per `tests/README.md`): for each doc file,
+extract the marker section, compare to the generator output.
+
+### Implementation steps
+
+1. **Registry + generic handler.** `model.py` (helper, spec, registry,
+   fold defaults, drop enum), `config.py` (drop style constants),
+   `dfd.py` (generic `handle_options`), `doc/CONVENTIONS.md`.
+   `make black`, `make lint`, `make test` — all 81 NR goldens must pass
+   unchanged. **Checkpoint**: user reviews the registry declaration style.
+2. **Doc generator + markers + prettier.** `tools/gen-style-tables.py`,
+   `tools/update-docs.sh`, markers in both docs, Makefile changes. Run
+   `make readme`; **checkpoint**: user reviews the resulting doc diff
+   (SYNTAX wording changes).
+3. **Drift test** in `tests/`. Mutation smoke-test: alter one doc string
+   in the registry, confirm the test fails, revert.
+4. **Wrap-up.** `CHANGES.md` 1.17.1, PR body update, `gh pr ready`.
+5. **Follow-up issue** for CLI flag derivation, opened after merge.

--- a/doc/CONVENTIONS.md
+++ b/doc/CONVENTIONS.md
@@ -49,7 +49,7 @@ Rules:
 
 - Abstract bases use semantic role names: `Statement`, `Drawable`.
 - Concrete types use domain nouns: `Item`, `Connection`, `Frame`.
-- Enums use singular nouns: `Keyword`, `StyleOption`.
+- Enums use singular nouns: `Keyword`.
 - Type aliases use descriptive plurals: `Statements`, `SourceLines`.
 
 ## Modules (files)
@@ -135,7 +135,10 @@ The package structure must work in all installation modes:
 ## Constants
 
 - **Configuration values** (defaults, thresholds): define in
-  `config.py` with `UPPER_SNAKE_CASE` names.
+  `config.py` with `UPPER_SNAKE_CASE` names. Exception: defaults of
+  `style` options live on the `GraphOptions` field declarations in
+  `model.py`, which are the single source of truth for those options
+  (keyword, type, default, documentation).
 - **Graphviz-specific constants** (templates, font specs, colours):
   define in `rendering/templates.py`.
 - **DSL syntax literals** (sentinel values, directive keywords):

--- a/doc/CONVENTIONS.md
+++ b/doc/CONVENTIONS.md
@@ -135,10 +135,7 @@ The package structure must work in all installation modes:
 ## Constants
 
 - **Configuration values** (defaults, thresholds): define in
-  `config.py` with `UPPER_SNAKE_CASE` names. Exception: defaults of
-  `style` options live on the `GraphOptions` field declarations in
-  `model.py`, which are the single source of truth for those options
-  (keyword, type, default, documentation).
+  `config.py` with `UPPER_SNAKE_CASE` names.
 - **Graphviz-specific constants** (templates, font specs, colours):
   define in `rendering/templates.py`.
 - **DSL syntax literals** (sentinel values, directive keywords):

--- a/doc/README.md
+++ b/doc/README.md
@@ -223,20 +223,24 @@ Process --> Channel
 The keyword `style` defines rendering parameters for the whole
 diagram:
 
+<!-- AUTO:style-table -->
+
 | Style statement                 | Effect                                                                            |
 | ------------------------------- | --------------------------------------------------------------------------------- |
-| `style background-color COLOR`  | Sets a graph background color as per https://graphviz.org/docs/attr-types/color/. |
-| `style connection-text-width N` | Sets the connections labels wrapping to use N chars columns.                      |
-| `style connection-text-size N`  | Sets the connection label text size                                               |
-| `style context`                 | Makes the diagram a context diagram.                                              |
 | `style horizontal`              | Layouts flows in the horizontal direction (the default).                          |
-| `style item-text-width N`       | Sets the items labels wrapping to use N chars columns.                            |
-| `style item-text-size N`        | Sets the items label text size                                                    |
-| `style no-graph-title`          | Suppress graph title containing the image file path (without extension).          |
-| `style graph-title-size N`      | Sets the graph title text size                                                    |
+| `style vertical`                | Layouts flows in the vertical direction.                                          |
 | `style rotated`                 | Rotates the diagram by 90°.                                                       |
 | `style unrotated`               | Reverts the diagram rotation, if any.                                             |
-| `style vertical`                | Layouts flows in the vertical direction.                                          |
+| `style context`                 | Makes the diagram a context diagram.                                              |
+| `style item-text-width N`       | Sets the items labels wrapping to use N chars columns.                            |
+| `style item-text-size N`        | Sets the items label text size.                                                   |
+| `style connection-text-width N` | Sets the connections labels wrapping to use N chars columns.                      |
+| `style connection-text-size N`  | Sets the connections label text size.                                             |
+| `style background-color COLOR`  | Sets a graph background color as per https://graphviz.org/docs/attr-types/color/. |
+| `style no-graph-title`          | Suppress graph title containing the image file path (without extension).          |
+| `style graph-title-size N`      | Sets the graph title text size.                                                   |
+
+<!-- /AUTO:style-table -->
 
 A style apply to the whole diagram, whatever where it is declared in
 the source. If a style is re-defined, the last declaration applies.

--- a/doc/SYNTAX.md
+++ b/doc/SYNTAX.md
@@ -198,20 +198,24 @@ one frame.
 style OPTION [VALUE]
 ```
 
-| Option                  | Value   | Effect                             |
-| ----------------------- | ------- | ---------------------------------- |
-| `horizontal`            | -       | Left-to-right layout (default)     |
-| `vertical`              | -       | Top-to-bottom layout               |
-| `context`               | -       | Context diagram mode               |
-| `rotated`               | -       | Rotate diagram 90 degrees          |
-| `unrotated`             | -       | Cancel rotation                    |
-| `item-text-width`       | integer | Item label wrap width (default 20) |
-| `item-text-size`        | integer | Item label text size (default 10)  |
-| `connection-text-width` | integer | Connection label wrap width (14)   |
-| `connection-text-size`  | integer | Connection label text size (10)    |
-| `background-color`      | color   | Graphviz color spec                |
-| `no-graph-title`        | -       | Suppress auto-generated title      |
-| `graph-title-size`      | integer | Graph title text size (default 9)  |
+<!-- AUTO:style-table -->
+
+| Option                  | Value   | Default | Effect                                                                            |
+| ----------------------- | ------- | ------- | --------------------------------------------------------------------------------- |
+| `horizontal`            | -       | -       | Layouts flows in the horizontal direction (the default).                          |
+| `vertical`              | -       | -       | Layouts flows in the vertical direction.                                          |
+| `rotated`               | -       | -       | Rotates the diagram by 90°.                                                       |
+| `unrotated`             | -       | -       | Reverts the diagram rotation, if any.                                             |
+| `context`               | -       | -       | Makes the diagram a context diagram.                                              |
+| `item-text-width`       | integer | 20      | Sets the items labels wrapping to use N chars columns.                            |
+| `item-text-size`        | integer | 10      | Sets the items label text size.                                                   |
+| `connection-text-width` | integer | 14      | Sets the connections labels wrapping to use N chars columns.                      |
+| `connection-text-size`  | integer | 10      | Sets the connections label text size.                                             |
+| `background-color`      | color   | -       | Sets a graph background color as per https://graphviz.org/docs/attr-types/color/. |
+| `no-graph-title`        | -       | -       | Suppress graph title containing the image file path (without extension).          |
+| `graph-title-size`      | integer | 9       | Sets the graph title text size.                                                   |
+
+<!-- /AUTO:style-table -->
 
 Styles apply globally. Last declaration wins if redefined.
 

--- a/src/data_flow_diagram/config.py
+++ b/src/data_flow_diagram/config.py
@@ -1,3 +1,11 @@
+# Default values for style options (see model.GraphOptions)
+
+DEFAULT_ITEM_TEXT_WIDTH = 20
+DEFAULT_ITEM_TEXT_SIZE = 10
+DEFAULT_CONNECTION_TEXT_WIDTH = 14
+DEFAULT_CONNECTION_TEXT_SIZE = 10
+DEFAULT_GRAPH_TITLE_SIZE = 9
+
 # Default Graphviz attributes applied during parsing
 
 ITEM_EXTERNAL_ATTRS = "fillcolor=white color=grey fontcolor=grey"

--- a/src/data_flow_diagram/config.py
+++ b/src/data_flow_diagram/config.py
@@ -1,12 +1,3 @@
-# Default values for options
-
-DEFAULT_ITEM_TEXT_WIDTH = 20
-DEFAULT_CONNECTION_TEXT_WIDTH = 14
-
-DEFAULT_CONNECTION_TEXT_SIZE = 10
-DEFAULT_ITEM_TEXT_SIZE = 10
-DEFAULT_GRAPH_TITLE_SIZE = 9
-
 # Default Graphviz attributes applied during parsing
 
 ITEM_EXTERNAL_ATTRS = "fillcolor=white color=grey fontcolor=grey"

--- a/src/data_flow_diagram/dfd.py
+++ b/src/data_flow_diagram/dfd.py
@@ -128,38 +128,28 @@ def handle_options(
     for statement in statements:
         match statement:
             case model.Style() as style:
-                match style.style:
-                    case model.StyleOption.VERTICAL:
-                        options.is_vertical = True
-                    case model.StyleOption.CONTEXT:
-                        options.is_context = True
-                    case model.StyleOption.HORIZONTAL:
-                        options.is_vertical = False
-                    case model.StyleOption.ROTATED:
-                        options.is_rotated = True
-                    case model.StyleOption.UNROTATED:
-                        options.is_rotated = False
-                    case model.StyleOption.ITEM_TEXT_WIDTH:
-                        options.item_text_width = get_style_int(statement)
-                    case model.StyleOption.CONNECTION_TEXT_WIDTH:
-                        options.connection_text_width = get_style_int(statement)
-                    case model.StyleOption.BACKGROUND_COLOR:
-                        options.background_color = style.value
-                    case model.StyleOption.NO_GRAPH_TITLE:
-                        options.no_graph_title = True
-                    case model.StyleOption.CONNECTION_TEXT_SIZE:
-                        options.connection_text_size = get_style_int(statement)
-                    case model.StyleOption.ITEM_TEXT_SIZE:
-                        options.item_text_size = get_style_int(statement)
-                    case model.StyleOption.GRAPH_TITLE_SIZE:
-                        options.graph_title_size = get_style_int(statement)
-                    case _:
-                        raise exception.DfdException(
-                            f'Unsupported style "{style.style}"',
-                            source=statement.source,
-                        )
-
+                apply_style(style, options)
                 continue
         new_statements.append(statement)
 
     return new_statements, options
+
+
+def apply_style(style: model.Style, options: model.GraphOptions) -> None:
+    """Set the GraphOptions field designated by a style statement."""
+    spec = model.STYLE_SPECS.get(style.style)
+    if spec is None:
+        raise exception.DfdException(
+            f'Unsupported style "{style.style}"', source=style.source
+        )
+
+    # convert the value as per the option kind
+    value: object
+    match spec.kind:
+        case "flag":
+            value = spec.value
+        case "int":
+            value = get_style_int(style)
+        case _:
+            value = style.value
+    setattr(options, spec.field, value)

--- a/src/data_flow_diagram/dfd.py
+++ b/src/data_flow_diagram/dfd.py
@@ -1,5 +1,7 @@
 """Pipeline orchestrator: scan → parse → check → resolve → filter → render."""
 
+from typing import assert_never
+
 from . import config, exception, model
 from .console import dprint
 from .dsl import checker, dependency_checker, filters, parser, scanner
@@ -146,10 +148,12 @@ def apply_style(style: model.Style, options: model.GraphOptions) -> None:
     # convert the value as per the option kind
     value: object
     match spec.kind:
-        case "flag":
+        case model.StyleKind.FLAG:
             value = spec.value
-        case "int":
+        case model.StyleKind.INT:
             value = get_style_int(style)
-        case _:
+        case model.StyleKind.STR:
             value = style.value
+        case _:
+            assert_never(spec.kind)
     setattr(options, spec.field, value)

--- a/src/data_flow_diagram/model.py
+++ b/src/data_flow_diagram/model.py
@@ -6,8 +6,8 @@ import dataclasses
 import json
 import typing
 from dataclasses import dataclass
-from enum import StrEnum
-from typing import Any, Literal, TypeVar
+from enum import Enum, StrEnum, auto
+from typing import Any, TypeVar, assert_never
 
 from . import config
 
@@ -63,10 +63,23 @@ class Statement(Base):
 
 T = TypeVar("T")
 
-# Metadata attached to each GraphOptions field: which `style` keyword(s) set
-# it and how it is documented. Everything else (registry, parsing, doc
-# tables) is derived from these declarations.
+# Declarations attached to GraphOptions fields as dataclass metadata: which
+# `style` keyword(s) set the field and how it is documented. Everything else
+# (registry, parsing, doc tables) is derived from these declarations.
 StyleFlags = dict[str, tuple[bool, str]]  # keyword -> (value, doc)
+STYLE_METADATA = "style"  # the single dataclass metadata key
+
+
+@dataclass(frozen=True)
+class StyleFlagsDecl:
+    flags: StyleFlags
+
+
+@dataclass(frozen=True)
+class StyleValueDecl:
+    name: str  # DSL keyword
+    doc: str
+    placeholder: str  # word shown for the value in the docs
 
 
 def declare_style_as_flags(*, default: bool, flags: StyleFlags) -> bool:
@@ -74,8 +87,8 @@ def declare_style_as_flags(*, default: bool, flags: StyleFlags) -> bool:
 
     `flags` maps each DSL keyword to the value it sets and its doc.
     """
-    metadata = {"kind": "flags", "flags": flags}
-    return dataclasses.field(default=default, metadata=metadata)
+    decl = StyleFlagsDecl(flags)
+    return dataclasses.field(default=default, metadata={STYLE_METADATA: decl})
 
 
 def declare_style_as_value(
@@ -86,13 +99,8 @@ def declare_style_as_value(
     `name` is the DSL keyword; `placeholder` is the word shown for the value
     in the docs. Type and default come from the field itself.
     """
-    metadata = {
-        "kind": "value",
-        "name": name,
-        "doc": doc,
-        "placeholder": placeholder,
-    }
-    return dataclasses.field(default=default, metadata=metadata)
+    decl = StyleValueDecl(name, doc, placeholder)
+    return dataclasses.field(default=default, metadata={STYLE_METADATA: decl})
 
 
 @dataclass
@@ -169,7 +177,10 @@ class GraphOptions:
     )
 
 
-StyleKind = Literal["flag", "int", "str"]
+class StyleKind(Enum):
+    FLAG = auto()  # keyword sets a fixed bool value
+    INT = auto()  # keyword takes an integer value
+    STR = auto()  # keyword takes a string value
 
 
 @dataclass(frozen=True)
@@ -188,15 +199,19 @@ def _build_style_specs() -> dict[str, StyleSpec]:
     specs: dict[str, StyleSpec] = {}
     hints = typing.get_type_hints(GraphOptions)
     for f in dataclasses.fields(GraphOptions):
-        md = f.metadata
-        if md["kind"] == "flags":
-            for keyword, (value, doc) in md["flags"].items():
-                specs[keyword] = StyleSpec(f.name, "flag", value, doc, "")
-        else:
-            kind: StyleKind = "int" if hints[f.name] is int else "str"
-            specs[md["name"]] = StyleSpec(
-                f.name, kind, f.default, md["doc"], md["placeholder"]
-            )
+        match f.metadata[STYLE_METADATA]:
+            case StyleFlagsDecl(flags):
+                for keyword, (value, doc) in flags.items():
+                    specs[keyword] = StyleSpec(
+                        f.name, StyleKind.FLAG, value, doc, ""
+                    )
+            case StyleValueDecl(name, doc, placeholder):
+                kind = StyleKind.INT if hints[f.name] is int else StyleKind.STR
+                specs[name] = StyleSpec(
+                    f.name, kind, f.default, doc, placeholder
+                )
+            case decl:
+                raise TypeError(f"unexpected style declaration {decl!r}")
     return specs
 
 

--- a/src/data_flow_diagram/model.py
+++ b/src/data_flow_diagram/model.py
@@ -4,11 +4,10 @@ from __future__ import annotations
 
 import dataclasses
 import json
+import typing
 from dataclasses import dataclass
 from enum import StrEnum
-from typing import Any
-
-from . import config
+from typing import Any, Literal, TypeVar
 
 
 def repr(o: Any) -> str:
@@ -60,18 +59,144 @@ class Statement(Base):
 # Statements: options
 
 
+T = TypeVar("T")
+
+# Metadata attached to each GraphOptions field: which `style` keyword(s) set
+# it and how it is documented. Everything else (registry, parsing, doc
+# tables) is derived from these declarations.
+StyleFlags = dict[str, tuple[bool, str]]  # keyword -> (value, doc)
+
+
+def style(
+    default: T,
+    *,
+    name: str = "",
+    doc: str = "",
+    placeholder: str = "N",
+    flags: StyleFlags | None = None,
+) -> T:
+    """Declare a GraphOptions field settable by a `style` statement.
+
+    Valued options (int or str fields) give `name` (the DSL keyword),
+    `doc`, and the `placeholder` word shown for the value in the docs.
+    Flag options (bool fields) give `flags`, mapping each DSL keyword to the
+    value it sets and its doc. Type and default come from the field itself.
+    """
+    metadata = {
+        "name": name,
+        "doc": doc,
+        "placeholder": placeholder,
+        "flags": flags or {},
+    }
+    return dataclasses.field(default=default, metadata=metadata)
+
+
 @dataclass
 class GraphOptions:
-    is_vertical: bool = False
-    is_context: bool = False
-    is_rotated: bool = False
-    item_text_width: int = config.DEFAULT_ITEM_TEXT_WIDTH
-    connection_text_width: int = config.DEFAULT_CONNECTION_TEXT_WIDTH
-    background_color: str | None = None
-    no_graph_title: bool = False
-    connection_text_size: int = config.DEFAULT_CONNECTION_TEXT_SIZE
-    item_text_size: int = config.DEFAULT_ITEM_TEXT_SIZE
-    graph_title_size: int = config.DEFAULT_GRAPH_TITLE_SIZE
+    """Whole-diagram rendering options. Declaration order is the doc order."""
+
+    # layout
+    is_vertical: bool = style(
+        False,
+        flags={
+            "horizontal": (
+                False,
+                "Layouts flows in the horizontal direction (the default).",
+            ),
+            "vertical": (True, "Layouts flows in the vertical direction."),
+        },
+    )
+    is_rotated: bool = style(
+        False,
+        flags={
+            "rotated": (True, "Rotates the diagram by 90°."),
+            "unrotated": (False, "Reverts the diagram rotation, if any."),
+        },
+    )
+    is_context: bool = style(
+        False,
+        flags={"context": (True, "Makes the diagram a context diagram.")},
+    )
+
+    # text
+    item_text_width: int = style(
+        20,
+        name="item-text-width",
+        doc="Sets the items labels wrapping to use N chars columns.",
+    )
+    item_text_size: int = style(
+        10,
+        name="item-text-size",
+        doc="Sets the items label text size.",
+    )
+    connection_text_width: int = style(
+        14,
+        name="connection-text-width",
+        doc="Sets the connections labels wrapping to use N chars columns.",
+    )
+    connection_text_size: int = style(
+        10,
+        name="connection-text-size",
+        doc="Sets the connections label text size.",
+    )
+
+    # graph
+    background_color: str | None = style(
+        None,
+        name="background-color",
+        placeholder="COLOR",
+        doc="Sets a graph background color as per "
+        "https://graphviz.org/docs/attr-types/color/.",
+    )
+    no_graph_title: bool = style(
+        False,
+        flags={
+            "no-graph-title": (
+                True,
+                "Suppress graph title containing the image file path "
+                "(without extension).",
+            ),
+        },
+    )
+    graph_title_size: int = style(
+        9,
+        name="graph-title-size",
+        doc="Sets the graph title text size.",
+    )
+
+
+StyleKind = Literal["flag", "int", "str"]
+
+
+@dataclass(frozen=True)
+class StyleSpec:
+    """One `style` keyword: the GraphOptions field it sets, and how."""
+
+    field: str
+    kind: StyleKind
+    value: Any  # fixed value for flags; default value otherwise
+    doc: str
+    placeholder: str  # value placeholder word in docs (valued options only)
+
+
+def _build_style_specs() -> dict[str, StyleSpec]:
+    """Derive the keyword registry from the GraphOptions declarations."""
+    specs: dict[str, StyleSpec] = {}
+    hints = typing.get_type_hints(GraphOptions)
+    for f in dataclasses.fields(GraphOptions):
+        md = f.metadata
+        if md["flags"]:
+            for keyword, (value, doc) in md["flags"].items():
+                specs[keyword] = StyleSpec(f.name, "flag", value, doc, "")
+        else:
+            kind: StyleKind = "int" if hints[f.name] is int else "str"
+            specs[md["name"]] = StyleSpec(
+                f.name, kind, f.default, md["doc"], md["placeholder"]
+            )
+    return specs
+
+
+STYLE_SPECS = _build_style_specs()  # keyword -> spec, in doc order
 
 
 @dataclass
@@ -146,25 +271,6 @@ class Only(Filter):
 @dataclass
 class Without(Filter):
     replaced_by: str
-
-
-##############################################################################
-# Style options
-
-
-class StyleOption(StrEnum):
-    VERTICAL = "vertical"
-    HORIZONTAL = "horizontal"
-    CONTEXT = "context"
-    ROTATED = "rotated"
-    UNROTATED = "unrotated"
-    ITEM_TEXT_WIDTH = "item-text-width"
-    CONNECTION_TEXT_WIDTH = "connection-text-width"
-    BACKGROUND_COLOR = "background-color"
-    NO_GRAPH_TITLE = "no-graph-title"
-    CONNECTION_TEXT_SIZE = "connection-text-size"
-    ITEM_TEXT_SIZE = "item-text-size"
-    GRAPH_TITLE_SIZE = "graph-title-size"
 
 
 ##############################################################################

--- a/src/data_flow_diagram/model.py
+++ b/src/data_flow_diagram/model.py
@@ -9,6 +9,8 @@ from dataclasses import dataclass
 from enum import StrEnum
 from typing import Any, Literal, TypeVar
 
+from . import config
+
 
 def repr(o: Any) -> str:
     name: str = o.__class__.__name__
@@ -67,26 +69,28 @@ T = TypeVar("T")
 StyleFlags = dict[str, tuple[bool, str]]  # keyword -> (value, doc)
 
 
-def style(
-    default: T,
-    *,
-    name: str = "",
-    doc: str = "",
-    placeholder: str = "N",
-    flags: StyleFlags | None = None,
-) -> T:
-    """Declare a GraphOptions field settable by a `style` statement.
+def declare_style_as_flags(*, default: bool, flags: StyleFlags) -> bool:
+    """Declare a bool GraphOptions field set by flag `style` keywords.
 
-    Valued options (int or str fields) give `name` (the DSL keyword),
-    `doc`, and the `placeholder` word shown for the value in the docs.
-    Flag options (bool fields) give `flags`, mapping each DSL keyword to the
-    value it sets and its doc. Type and default come from the field itself.
+    `flags` maps each DSL keyword to the value it sets and its doc.
+    """
+    metadata = {"kind": "flags", "flags": flags}
+    return dataclasses.field(default=default, metadata=metadata)
+
+
+def declare_style_as_value(
+    *, default: T, name: str, doc: str, placeholder: str = "N"
+) -> T:
+    """Declare an int or str GraphOptions field set by a valued `style` keyword.
+
+    `name` is the DSL keyword; `placeholder` is the word shown for the value
+    in the docs. Type and default come from the field itself.
     """
     metadata = {
+        "kind": "value",
         "name": name,
         "doc": doc,
         "placeholder": placeholder,
-        "flags": flags or {},
     }
     return dataclasses.field(default=default, metadata=metadata)
 
@@ -96,8 +100,8 @@ class GraphOptions:
     """Whole-diagram rendering options. Declaration order is the doc order."""
 
     # layout
-    is_vertical: bool = style(
-        False,
+    is_vertical: bool = declare_style_as_flags(
+        default=False,
         flags={
             "horizontal": (
                 False,
@@ -106,50 +110,50 @@ class GraphOptions:
             "vertical": (True, "Layouts flows in the vertical direction."),
         },
     )
-    is_rotated: bool = style(
-        False,
+    is_rotated: bool = declare_style_as_flags(
+        default=False,
         flags={
             "rotated": (True, "Rotates the diagram by 90°."),
             "unrotated": (False, "Reverts the diagram rotation, if any."),
         },
     )
-    is_context: bool = style(
-        False,
+    is_context: bool = declare_style_as_flags(
+        default=False,
         flags={"context": (True, "Makes the diagram a context diagram.")},
     )
 
     # text
-    item_text_width: int = style(
-        20,
+    item_text_width: int = declare_style_as_value(
+        default=config.DEFAULT_ITEM_TEXT_WIDTH,
         name="item-text-width",
         doc="Sets the items labels wrapping to use N chars columns.",
     )
-    item_text_size: int = style(
-        10,
+    item_text_size: int = declare_style_as_value(
+        default=config.DEFAULT_ITEM_TEXT_SIZE,
         name="item-text-size",
         doc="Sets the items label text size.",
     )
-    connection_text_width: int = style(
-        14,
+    connection_text_width: int = declare_style_as_value(
+        default=config.DEFAULT_CONNECTION_TEXT_WIDTH,
         name="connection-text-width",
         doc="Sets the connections labels wrapping to use N chars columns.",
     )
-    connection_text_size: int = style(
-        10,
+    connection_text_size: int = declare_style_as_value(
+        default=config.DEFAULT_CONNECTION_TEXT_SIZE,
         name="connection-text-size",
         doc="Sets the connections label text size.",
     )
 
     # graph
-    background_color: str | None = style(
-        None,
+    background_color: str | None = declare_style_as_value(
+        default=None,
         name="background-color",
         placeholder="COLOR",
         doc="Sets a graph background color as per "
         "https://graphviz.org/docs/attr-types/color/.",
     )
-    no_graph_title: bool = style(
-        False,
+    no_graph_title: bool = declare_style_as_flags(
+        default=False,
         flags={
             "no-graph-title": (
                 True,
@@ -158,8 +162,8 @@ class GraphOptions:
             ),
         },
     )
-    graph_title_size: int = style(
-        9,
+    graph_title_size: int = declare_style_as_value(
+        default=config.DEFAULT_GRAPH_TITLE_SIZE,
         name="graph-title-size",
         doc="Sets the graph title text size.",
     )
@@ -185,7 +189,7 @@ def _build_style_specs() -> dict[str, StyleSpec]:
     hints = typing.get_type_hints(GraphOptions)
     for f in dataclasses.fields(GraphOptions):
         md = f.metadata
-        if md["flags"]:
+        if md["kind"] == "flags":
             for keyword, (value, doc) in md["flags"].items():
                 specs[keyword] = StyleSpec(f.name, "flag", value, doc, "")
         else:

--- a/tests/README.md
+++ b/tests/README.md
@@ -66,6 +66,14 @@ No fixture file needed.
 
 **Example to follow:** `tests/test_integration.py::test_stdin_to_stdout_produces_svg`.
 
+### Documentation sync test
+
+**File:** `tests/test_doc_sync.py`
+
+Guards generated documentation sections (`<!-- AUTO:... -->` markers) against
+drifting from the code they are derived from. When it fails, run `make readme`
+and commit the refreshed docs. Extend it when adding a new generated section.
+
 ### Non-regression test — nominal (success)
 
 **Fixtures (inputs):** `tests/non-regression/NNN-name.dfd` (standalone) or

--- a/tests/test_doc_sync.py
+++ b/tests/test_doc_sync.py
@@ -1,0 +1,44 @@
+"""Documentation sync tests.
+
+The style option tables in doc/README.md and doc/SYNTAX.md are generated
+from the GraphOptions declarations (see tools/gen-style-tables.py). These
+tests fail when the docs drift from the code; run `make readme` to refresh.
+"""
+
+import pathlib
+import subprocess
+import sys
+
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+GENERATOR = ROOT / "tools" / "gen-style-tables.py"
+
+
+def extract_auto_section(text: str, name: str) -> str:
+    """Return the content between <!-- AUTO:name --> markers, stripped."""
+    open_marker = f"<!-- AUTO:{name} -->"
+    close_marker = f"<!-- /AUTO:{name} -->"
+    start = text.index(open_marker) + len(open_marker)
+    end = text.index(close_marker)
+    return text[start:end].strip()
+
+
+@pytest.mark.parametrize(
+    "doc, table",
+    [
+        pytest.param("doc/README.md", "readme", id="readme"),
+        pytest.param("doc/SYNTAX.md", "syntax", id="syntax"),
+    ],
+)
+def test_style_table_in_sync(doc: str, table: str) -> None:
+    # regenerate the table and compare with the committed doc section
+    result = subprocess.run(
+        [sys.executable, str(GENERATOR), table],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    expected = result.stdout.strip()
+    actual = extract_auto_section((ROOT / doc).read_text(), "style-table")
+    assert actual == expected, f"{doc} style table is stale: run 'make readme'"

--- a/tools/gen-style-tables.py
+++ b/tools/gen-style-tables.py
@@ -11,6 +11,7 @@ like prettier / VSCode format tables, so re-formatting produces no diff.
 import pathlib
 import sys
 from collections.abc import Iterator
+from typing import assert_never
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent / "src"))
 
@@ -32,7 +33,7 @@ def format_table(header: list[str], rows: list[list[str]]) -> str:
 def readme_rows() -> Iterator[list[str]]:
     """Rows for doc/README.md: full statement form and effect."""
     for keyword, spec in model.STYLE_SPECS.items():
-        if spec.kind == "flag":
+        if spec.kind is model.StyleKind.FLAG:
             statement = f"`style {keyword}`"
         else:
             statement = f"`style {keyword} {spec.placeholder}`"
@@ -43,13 +44,15 @@ def syntax_rows() -> Iterator[list[str]]:
     """Rows for doc/SYNTAX.md: option, value kind, default, and effect."""
     for keyword, spec in model.STYLE_SPECS.items():
         match spec.kind:
-            case "flag":
+            case model.StyleKind.FLAG:
                 value, default = "-", "-"
-            case "int":
+            case model.StyleKind.INT:
                 value, default = "integer", str(spec.value)
-            case _:
+            case model.StyleKind.STR:
                 value = spec.placeholder.lower()
                 default = "-" if spec.value is None else str(spec.value)
+            case _:
+                assert_never(spec.kind)
         yield [f"`{keyword}`", value, default, spec.doc]
 
 

--- a/tools/gen-style-tables.py
+++ b/tools/gen-style-tables.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Print the `style` options table of doc/README.md or doc/SYNTAX.md.
+
+Usage: gen-style-tables.py readme|syntax
+
+The tables are derived from data_flow_diagram.model.STYLE_SPECS, so the
+GraphOptions declarations stay the single source of truth. Output is padded
+like prettier / VSCode format tables, so re-formatting produces no diff.
+"""
+
+import pathlib
+import sys
+from collections.abc import Iterator
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent / "src"))
+
+from data_flow_diagram import model  # noqa: E402
+
+
+def format_table(header: list[str], rows: list[list[str]]) -> str:
+    """Render a Markdown table with every column padded to its widest cell."""
+    widths = [max(len(cell) for cell in col) for col in zip(header, *rows)]
+
+    def line(cells: list[str]) -> str:
+        padded = [cell.ljust(w) for cell, w in zip(cells, widths)]
+        return "| " + " | ".join(padded) + " |"
+
+    separator = ["-" * w for w in widths]
+    return "\n".join([line(header), line(separator), *map(line, rows)])
+
+
+def readme_rows() -> Iterator[list[str]]:
+    """Rows for doc/README.md: full statement form and effect."""
+    for keyword, spec in model.STYLE_SPECS.items():
+        if spec.kind == "flag":
+            statement = f"`style {keyword}`"
+        else:
+            statement = f"`style {keyword} {spec.placeholder}`"
+        yield [statement, spec.doc]
+
+
+def syntax_rows() -> Iterator[list[str]]:
+    """Rows for doc/SYNTAX.md: option, value kind, default, and effect."""
+    for keyword, spec in model.STYLE_SPECS.items():
+        match spec.kind:
+            case "flag":
+                value, default = "-", "-"
+            case "int":
+                value, default = "integer", str(spec.value)
+            case _:
+                value = spec.placeholder.lower()
+                default = "-" if spec.value is None else str(spec.value)
+        yield [f"`{keyword}`", value, default, spec.doc]
+
+
+def main() -> None:
+    match sys.argv[1:]:
+        case ["readme"]:
+            print(
+                format_table(["Style statement", "Effect"], list(readme_rows()))
+            )
+        case ["syntax"]:
+            header = ["Option", "Value", "Default", "Effect"]
+            print(format_table(header, list(syntax_rows())))
+        case _:
+            sys.exit(f"usage: {sys.argv[0]} readme|syntax")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/update-docs.sh
+++ b/tools/update-docs.sh
@@ -1,28 +1,36 @@
 #!/usr/bin/env bash
 #
-# Regenerate auto-updatable sections of README.md.
+# Regenerate auto-updatable sections of README.md and doc/*.md.
 #
 # Each section is demarcated by HTML comment markers:
 #   <!-- AUTO:section-name -->
 #   ...generated content...
 #   <!-- /AUTO:section-name -->
 #
-# The script replaces everything between the markers.
-# Hand-edited content outside markers is never touched.
+# The script replaces everything between the markers, then reformats the
+# touched files with prettier so that editor auto-formatting (VSCode +
+# prettier) produces no further diff. Hand-edited content outside markers
+# is never touched.
+#
+# Environment: VENV (default .venv) locates prettier, installed there by
+# `make require`.
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+VENV="${VENV:-$ROOT_DIR/.venv}"
 README="$ROOT_DIR/README.md"
+DOC_README="$ROOT_DIR/doc/README.md"
+DOC_SYNTAX="$ROOT_DIR/doc/SYNTAX.md"
 
 # ── section generators ───────────────────────────────────────────────
 
 generate_cli_help() {
     # activate venv if present, so the local entry point works
-    if [[ -f "$ROOT_DIR/.venv/bin/activate" ]]; then
+    if [[ -f "$VENV/bin/activate" ]]; then
         # shellcheck disable=SC1091
-        source "$ROOT_DIR/.venv/bin/activate"
+        source "$VENV/bin/activate"
     fi
 
     echo '````'
@@ -32,8 +40,7 @@ generate_cli_help() {
 
 generate_doc_toc() {
     # extract level-2 headings from doc/README.md and build a linked list
-    local doc="$ROOT_DIR/doc/README.md"
-    grep -n '^## ' "$doc" | while IFS=: read -r _ line; do
+    grep -n '^## ' "$DOC_README" | while IFS=: read -r _ line; do
         # strip the "## " prefix and any trailing whitespace
         title="${line#\#\# }"
         title="${title%"${title##*[![:space:]]}"}"
@@ -46,12 +53,17 @@ generate_doc_toc() {
     done
 }
 
+generate_style_table() {
+    # $1: readme|syntax
+    "$SCRIPT_DIR/gen-style-tables.py" "$1"
+}
+
 # ── generic marker replacement ───────────────────────────────────────
 
 replace_section() {
-    local section_name="$1"
-    local new_content="$2"
-    local file="$README"
+    local file="$1"
+    local section_name="$2"
+    local new_content="$3"
 
     local open_marker="<!-- AUTO:${section_name} -->"
     local close_marker="<!-- /AUTO:${section_name} -->"
@@ -75,18 +87,30 @@ replace_section() {
     ' "$file" > "${file}.tmp"
 
     mv "${file}.tmp" "$file"
+    echo "  - $(realpath --relative-to="$ROOT_DIR" "$file"): $section_name done"
+}
+
+# ── prettier ─────────────────────────────────────────────────────────
+
+reformat() {
+    local prettier="$VENV/node_modules/.bin/prettier"
+    if [[ ! -x "$prettier" ]]; then
+        echo "warning: $prettier not found (run 'make require') — skipping reformat" >&2
+        return
+    fi
+    "$prettier" --log-level warn --write "$@"
+    echo "  - prettier: done"
 }
 
 # ── main ─────────────────────────────────────────────────────────────
 
-echo "Updating README.md auto-generated sections..."
+echo "Updating auto-generated sections..."
 
-cli_help=$(generate_cli_help)
-replace_section "cli-help" "$cli_help"
-echo "  - cli-help: done"
+replace_section "$README" "cli-help" "$(generate_cli_help)"
+replace_section "$README" "doc-toc" "$(generate_doc_toc)"
+replace_section "$DOC_README" "style-table" "$(generate_style_table readme)"
+replace_section "$DOC_SYNTAX" "style-table" "$(generate_style_table syntax)"
 
-doc_toc=$(generate_doc_toc)
-replace_section "doc-toc" "$doc_toc"
-echo "  - doc-toc: done"
+reformat "$README" "$DOC_README" "$DOC_SYNTAX"
 
-echo "README.md updated."
+echo "Done."


### PR DESCRIPTION
Closes #71.

`style` options are now declared in one place: the `GraphOptions` field declarations in `model.py` carry keyword(s), doc, and type as field metadata, and reference their default constant in `config.py`. Everything else is derived. See [devlog/071-streamline-style-options.md](devlog/071-streamline-style-options.md).

**Before:** six edit sites in five files per option (`config.py` default, `GraphOptions` field, `StyleOption` member, `handle_options` case, two doc tables).
**After:** one field declaration (plus its default constant in `config.py` for valued options), then `make readme`.

- [x] Registry derived from field metadata (`model.declare_style_as_flags()` / `declare_style_as_value()`, `STYLE_SPECS`); `StyleOption` enum removed; `handle_options` generic
- [x] `tools/gen-style-tables.py` generates the style tables of `doc/README.md` and `doc/SYNTAX.md` into `AUTO:style-table` markers
- [x] `tools/update-readme.sh` → `tools/update-docs.sh`; reformats touched docs with prettier (installed in the venv by `make require`; `make require-system` adds npm)
- [x] Drift test `tests/test_doc_sync.py` (mutation smoke-tested)
- [x] `doc/CONVENTIONS.md`, `tests/README.md`, `CHANGES.md` 1.17.1
- [x] Behavior byte-identical: all 81 NR goldens unchanged

Out of scope, to be a separate task: deriving CLI flags from the same metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T4TftZaxoMXSA1DnTJzRm1